### PR TITLE
Use the actual commit data to create a Commit object

### DIFF
--- a/github3/repos.py
+++ b/github3/repos.py
@@ -1471,7 +1471,7 @@ class Branch(GitHubCore):
         #  ``None``.
         self.commit = None
         if branch.get('commit'):
-            self.commit = Commit(branch.get('commit'), self._session)
+            self.commit = Commit(branch['commit']['commit'], self._session)
         #: Returns '_links' attribute.
         self.links = branch.get('_links', {})
 


### PR DESCRIPTION
Branch.**init** now uses the actual commit data to create a commit
instead of the data suitable for RepoCommit.

This is needed because author/committer will be null if they are not
made by people known to github, eg in
https://github.com/edmonds/nss-ubdns/
