### PR TITLE
Don't break when a commit's committer is not on github

### DIFF
--- a/github3/repos.py
+++ b/github3/repos.py
@@ -1957,10 +1957,13 @@ class RepoCommit(BaseCommit):
 
     def __init__(self, commit, session=None):
         super(RepoCommit, self).__init__(commit, session)
+        self.author = self.committer = None
         #: :class:`User <github3.users.User>` who authored the commit.
-        self.author = User(commit.get('author'), self._session)
+        if commit.get('author'):
+            self.author = User(commit.get('author'), self._session)
         #: :class:`User <github3.users.User>` who committed the commit.
-        self.committer = User(commit.get('committer'), self._session)
+        if commit.get('committer'):
+            self.committer = User(commit.get('committer'), self._session)
         #: :class:`Commit <github3.git.Commit>`.
         self.commit = Commit(commit.get('commit'), self._session)
 


### PR DESCRIPTION
When the author or commiter of a commit are not known to github,
RepoCommit.**init** used to crash.

Examples of such commits are most commits in edmonds/nss_ubdns
