### PR TITLE
Better error messages for authorization methods

### DIFF
--- a/github3/auths.py
+++ b/github3/auths.py
@@ -6,6 +6,7 @@ This module contains the Authorization object.
 
 """
 
+from github3.decorators import requires_basic_auth
 from github3.models import GitHubCore
 from json import dumps
 
@@ -44,10 +45,12 @@ class Authorization(GitHubCore):
     def _update_(self, auth):
         self.__init__(auth, self._session)
 
+    @requires_basic_auth
     def delete(self):
         """delete this authorization"""
         return self._boolean(self._delete(self._api), 204, 404)
 
+    @requires_basic_auth
     def update(self, scopes=[], add_scopes=[], rm_scopes=[], note='',
             note_url=''):
         """Update this authorization.

--- a/github3/decorators.py
+++ b/github3/decorators.py
@@ -50,3 +50,33 @@ def requires_auth(func):
             r.raw = StringIO('{"message": "Requires authentication"}'.encode())
             raise GitHubError(r)
     return auth_wrapper
+
+def requires_basic_auth(func):
+    """Decorator to note which object methods require username/password
+    authorization and won't work with token based authorization.
+
+    .. note::
+        This decorator causes the wrapped methods to lose their proper
+        signature. Please refer to the documentation for each of those.
+    """
+    #note = """.. note::
+    #The signature of this function may not appear correctly in
+    #documentation. Please adhere to the defined parameters and their
+    #types.
+    #"""
+    ## Append the above note to each function this is applied to
+    #func.__doc__ = '\n\n'.join([func.__doc__, note])
+
+    @wraps(func)
+    def auth_wrapper(self, *args, **kwargs):
+        if hasattr(self, '_session') and self._session.auth:
+            return func(self, *args, **kwargs)
+        else:
+            from github3.models import GitHubError
+            # Mock a 401 response
+            r = Response()
+            r.status_code = 401
+            r.encoding = 'utf-8'
+            r.raw = StringIO('{"message": "Requires username/password authentication"}'.encode())
+            raise GitHubError(r)
+    return auth_wrapper

--- a/github3/github.py
+++ b/github3/github.py
@@ -17,7 +17,7 @@ from github3.models import GitHubCore
 from github3.orgs import Organization
 from github3.repos import Repository
 from github3.users import User, Key
-from github3.decorators import requires_auth
+from github3.decorators import requires_auth, requires_basic_auth
 
 
 class GitHub(GitHubCore):
@@ -40,7 +40,7 @@ class GitHub(GitHubCore):
         url = self._build_url('user', which)
         return self._iter(number, url, User)
 
-    @requires_auth
+    @requires_basic_auth
     def authorization(self, id_num):
         """Get information about authorization ``id``.
 
@@ -320,7 +320,7 @@ class GitHub(GitHubCore):
             return repo.issue(number)
         return None
 
-    @requires_auth
+    @requires_basic_auth
     def list_authorizations(self):
         """List authorizations for the authenticated user.
 
@@ -330,7 +330,7 @@ class GitHub(GitHubCore):
         json = self._json(self._get(url), 200)
         return [Authorization(a, self) for a in json]
 
-    @requires_auth
+    @requires_basic_auth
     def iter_authorizations(self, number=-1):
         """Iterate over authorizations for the authenticated user.
 


### PR DESCRIPTION
From http://developer.github.com/v3/oauth/:

"""
There is an API for users to manage their own tokens. You can only
access your own tokens, and only through Basic Authentication.
"""

When using token based auth to access these methods, you get a very
unhelpful 404 error. Let's be nicer to our API users and turn that into
a fake 401.
