### PR TITLE
Set Content-Type correctly for requests

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,5 @@ Contributors
 - Hong Minhee (@dahlia)
 
 - Paul Swartz (@paulswartz)
+
+- Kristian Glass (@doismellburning)

--- a/github3/models.py
+++ b/github3/models.py
@@ -62,6 +62,8 @@ class GitHubCore(GitHubObject):
                 'Accept': 'application/vnd.github.v3.full+json',
                 # Only accept UTF-8 encoded data
                 'Accept-Charset': 'utf-8',
+                # Always sending JSON
+                'Content-Type': "application/json",
                 # Set our own custom User-Agent string
                 'User-Agent': 'github3.py/0.1b0',
                 }


### PR DESCRIPTION
Most of the time, GitHub will be fine without an explicit Content-Type,
until you start putting % characters in there (fairly reasonably!)
