### PR TITLE
Repository.master_branch defaults to None not '' now as per docs

### DIFF
--- a/github3/repos.py
+++ b/github3/repos.py
@@ -106,7 +106,7 @@ class Repository(GitHubCore):
             self.parent = Repository(self.parent, self)
 
         #: default branch for the repository
-        self.master_branch = repo.get('master_branch', '')
+        self.master_branch = repo.get('master_branch')
 
     def __repr__(self):
         return '<Repository [{0}/{1}]>'.format(self.owner.login, self.name)


### PR DESCRIPTION
Sorry again for lack of test; wasn't clear on best way.

Is it worth a dedicated set of Org/Repos/etc. in predefined states?
