### PR TITLE
GitHubCore.refresh() to return the refreshed instance

### DIFF
--- a/github3/models.py
+++ b/github3/models.py
@@ -183,9 +183,11 @@ class GitHubCore(GitHubObject):
         return self._remaining
 
     def refresh(self):
-        """Re-retrieve the information for this object."""
+        """Re-retrieve the information for this object and returns the refreshed
+        instance."""
         json = self._json(self._get(self._api), 200)
         self.__init__(json, self._session)
+        return self
 
 
 class BaseComment(GitHubCore):


### PR DESCRIPTION
That allows to get a refreshed list of objects as easily as:

``` python
repos = [repo.refresh() for repo in foo.iter_repos()]
```

I was lazy enough not to contribute tests nor documentation, I'm sorry.
