### PR TITLE
Add User.iter_keys

### DIFF
--- a/github3/users.py
+++ b/github3/users.py
@@ -215,6 +215,16 @@ class User(BaseAccount):
         url = self._build_url('following', base_url=self._api)
         return self._iter(int(number), url, User)
 
+    def iter_keys(self, number=-1):
+        """Iterate over the public keys of this user.
+
+        :param int number: (optional), number of keys to return. Default: -1
+            returns all available keys
+        :returns: generator of :class:`Key <Key>`\ s
+        """
+        url = self._build_url('keys', base_url=self._api)
+        return self._iter(int(number), url, Key)
+
     def iter_org_events(self, org, number=-1):
         """Iterate over events as they appear on the user's organization
         dashboard. You must be authenticated to view this.

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -239,6 +239,9 @@ class TestUser(BaseCase):
             github3.repos.Repository)
         self.mock_assertions()
 
+    def test_iter_keys(self):
+        expect(next(self.user.iter_keys(1))).isinstance(Key)
+
     def test_update(self):
         self.response('user', 200)
         self.patch('https://api.github.com/user')


### PR DESCRIPTION
This API call now works, so let's add it to github3.py too. Sadly it
does not return the key titles like github.iter_keys().
