### PR TITLE
One-liner to add a 'since' parameter to iter_all_repos 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,3 +37,5 @@ Contributors
 - Malcolm Box (@mbox)
 
 - Tom Petr (@tpetr)
+
+- David Pachura (@detenebrator)

--- a/github3/github.py
+++ b/github3/github.py
@@ -327,17 +327,20 @@ class GitHub(GitHubCore):
             return repo.issue(number)
         return None
 
-    def iter_all_repos(self, number=-1, etag=None):
+    def iter_all_repos(self, number=-1, since=None, etag=None):
         """Iterate over every repository in the order they were created.
 
         :param int number: (optional), number of repositories to return.
             Default: -1, returns all of them
+        :param int since: (optional), last repository id seen (allows
+            restarting this iteration)
         :param str etag: (optional), ETag from a previous request to the same
             endpoint
         :returns: generator of :class:`Repository <github3.repos.Repository>`
         """
         url = self._build_url('repositories')
-        return self._iter(int(number), url, Repository, etag=etag)
+        params = {'since': since} if since else None
+        return self._iter(int(number), url, Repository, params=params, etag=etag)
 
     def iter_all_users(self, number=-1, etag=None):
         """Iterate over every user in the order they signed up for GitHub.

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ packages = [
     "github3",
     "github3.gists",
     "github3.repos",
+    "github3.issues",
 ]
 
 try:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -212,6 +212,14 @@ class TestGitHub(BaseCase):
         expect(repo).isinstance(github3.repos.Repository)
         self.mock_assertions()
 
+        self.response('repo', _iter=True)
+        self.get('https://api.github.com/repositories')
+        self.conf.update(params={'since': 100000})
+        repo = next(self.g.iter_all_repos(since=100000))
+        expect(repo).isinstance(github3.repos.Repository)
+        assert(repo.id > 100000)
+        self.mock_assertions()
+
     def test_iter_all_users(self):
         self.response('user', _iter=True)
         self.get('https://api.github.com/users')


### PR DESCRIPTION
I needed to be able to restart a fetch of all projects on github.  Since the rate limit is
5000/hr, restarting after 100,000 project records meant days of repeated data.  Since
Github's API has it, it was about one line to fix.

I added a test to test_iter_all_repos to test the parameter as well.
