### PR TITLE
Use tests_require instead of install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ packages = [
 try:
     from setuptools import setup
     kwargs['test_suite'] = 'run_tests.collect_tests'
-    requires = ['mock', 'expecter', 'coverage==3.5.2']
+    kwargs['tests_require'] = ['mock', 'expecter', 'coverage==3.5.2']
     packages.append('tests')
 except ImportError:
     from distutils.core import setup  # NOQA


### PR DESCRIPTION
Previously some dependencies for unit testing were mixed with other dependencies in `install_requires` option.

Distribute (was setuptools) provides `tests_require` option to describe dependencies only for testing, so we’d better to utilize it.  More over it doesn’t require administrator permission even if you aren’t using virtualenv—it simply unpacks dependencies on working directory instead.

http://pythonhosted.org/distribute/setuptools.html#new-and-changed-setup-keywords
