### PR TITLE
Set Makefile default goal to `tests` instead of `clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 COVERAGE_INCLUDE := github3/*.py
 TEST_RUNNER := run_tests.py
 
+.DEFAULT_GOAL := tests
+
 clean:
 	git clean -Xdf
 	rm -rf build/ dist/


### PR DESCRIPTION
By virtue of being the first goal in the Makefile, `clean` is currently
the default. Personally I feel this is slightly aggressive (having
accidentally wiped out scratch files twice now due to bare `make`s) so
this sets `.DEFAULT_GOAL` to `tests`, which is non-destructive and
(based on no data other than my own usage) probably more desired.
