### PR TITLE
Using etag value in iter_repo_issues

### DIFF
--- a/github3/github.py
+++ b/github3/github.py
@@ -609,7 +609,7 @@ class GitHub(GitHubCore):
         if owner and repository:
             repo = self.repository(owner, repository)
             return repo.iter_issues(milestone, state, assignee, mentioned,
-                                    labels, sort, direction, since, number)
+                                    labels, sort, direction, since, number, etag)
         return iter([])
 
     @requires_auth


### PR DESCRIPTION
The `etag` parameter in [github.iter_repo_issues](https://github.com/sigmavirus24/github3.py/blob/develop/github3/github.py#L581) was previously not being used.
