### PR TITLE
When issuing pull requests, pull requests seem to have /pull/ as the issue_url.  Allow both types to appear.

### DIFF
--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -166,7 +166,7 @@ class PullRequest(GitHubCore):
         #: The URL of the patch
         self.patch_url = pull.get('patch_url')
 
-        m = match('https://github\.com/(\S+)/(\S+)/issues/\d+',
+        m = match('https://github\.com/(\S+)/(\S+)/(?:issues|pull)?/\d+',
                   self.issue_url)
         #: Returns ('owner', 'repository') this issue was filed on.
         self.repository = m.groups()


### PR DESCRIPTION
FYI -- http://developer.github.com/v3/pulls/ also seems to have singular issue, not issues.
