### PR TITLE
Allow removing milestone in Issue.edit()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,3 +51,5 @@ Contributors
 - Aleksey Ostapenko (@kbakba)
 
 - Vincent Driessen (@nvie)
+
+- Philip Chimento (@ptomato)

--- a/github3/issues/issue.py
+++ b/github3/issues/issue.py
@@ -185,7 +185,7 @@ class Issue(GitHubCore):
             to
         :param str state: accepted values: ('open', 'closed')
         :param int milestone: the NUMBER (not title) of the milestone to
-            assign this to [1]_
+            assign this to [1]_, or 0 to remove the milestone
         :param list labels: list of labels to apply this to
         :returns: bool
 
@@ -197,6 +197,8 @@ class Issue(GitHubCore):
                 'state': state, 'milestone': milestone, 'labels': labels}
         self._remove_none(data)
         if data:
+            if 'milestone' in data and data['milestone'] == 0:
+                data['milestone'] = None
             json = self._json(self._patch(self._api, data=dumps(data)), 200)
         if json:
             self._update_(json)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -220,7 +220,7 @@ class TestIssue(BaseCase):
     def test_edit(self):
         self.response('issue', 200)
         self.patch(self.api)
-        self.conf = {'data': {'title': 'new title'}}
+        self.conf = {'data': {'title': 'new title', 'milestone': None}}
 
         self.assertRaises(github3.GitHubError, self.i.edit)
 
@@ -228,7 +228,7 @@ class TestIssue(BaseCase):
         assert self.i.edit() is False
         self.not_called()
 
-        assert self.i.edit('new title')
+        assert self.i.edit('new title', milestone=0)
         self.mock_assertions()
 
     def test_is_closed(self):


### PR DESCRIPTION
Pass milestone=0 to remove a milestone.

This is new API from GitHub; they require passing a null milestone, so
change 0 to None after removing all the default None parameters from
the JSON dict.
