### PR TITLE
Return the empty string for empty gitignore templates

### DIFF
--- a/github3/github.py
+++ b/github3/github.py
@@ -316,6 +316,8 @@ class GitHub(GitHubCore):
         """
         url = self._build_url('gitignore', 'templates', language)
         json = self._json(self._get(url), 200)
+        if not json:
+            return ''
         return json.get('source', '')
 
     def gitignore_templates(self):


### PR DESCRIPTION
Let's not crash trying to interpret None as json, but return an empty
string instead.
