### PR TITLE
Expose the stargazers count for repositories

### DIFF
--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -124,6 +124,10 @@ class Repository(GitHubCore):
         #: Size of the repository.
         self.size = repo.get('size', 0)
 
+        # The number of stargazers
+        #: Number of users who starred the repository
+        self.stargazers = repo.get('stargazers_count', 0)
+
         # SSH url e.g. git@github.com/sigmavirus24/github3.py
         #: URL to clone the repository via SSH.
         self.ssh_url = repo.get('ssh_url', '')


### PR DESCRIPTION
I'm now using repo._json_data['stargazers_count'], which is a hack.
Making it part of the proper API.
