### PR TITLE
setup.py fixes: ship what we intend to ship

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,12 @@ include README.rst
 include LICENSE
 include HISTORY.rst
 include AUTHORS.rst
+include CONTRIBUTING.rst
+include tox.ini
+include report_issue.py
 prune *.pyc
-recursive-include github3/
-recursive-include docs/
+recursive-include docs *.rst *.py Makefile
+recursive-include tests *.py *.json
+recursive-include tests/json *
+recursive-include images *.png
 prune docs/_build

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ packages = [
 kwargs['tests_require'] = ['mock == 1.0.1', 'betamax >=0.1.6', 'pytest']
 if sys.version_info < (3, 0):
     kwargs['tests_require'].append('unittest2==0.5.1')
-packages.append('tests')
 
 if sys.argv[-1] in ("submit", "publish"):
     os.system("python setup.py bdist_wheel sdist upload")
@@ -66,8 +65,6 @@ setup(
     author_email="graffatcolmingov@gmail.com",
     url="https://github3py.readthedocs.org",
     packages=packages,
-    package_data={'': ['LICENSE', 'AUTHORS.rst']},
-    include_package_data=True,
     install_requires=requires,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
- Fix MANIFEST.in entries so files actually get included
- Add all tests and test data to MANIFEST.in so they get shipped in the
  source tarball
- Add some more files to MANIFEST.in from the root of the git tree
- Drop tests/ from packages and drop package_data so irrelevant files do
  not get installed into bdists or with setup.py install
