### PR TITLE
Fix minor doc bug on Repository.iter_issues

### DIFF
--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -1312,7 +1312,8 @@ class Repository(GitHubCore):
         :param str assignee: (optional), 'none', '*', or login name
         :param str mentioned: (optional), user's login name
         :param str labels: (optional), comma-separated list of labels, e.g.
-            'bug,ui,@high' :param sort: accepted values:
+            'bug,ui,@high'
+        :param sort: (optional), accepted values:
             ('created', 'updated', 'comments', 'created')
         :param str direction: (optional), accepted values: ('asc', 'desc')
         :param since: (optional), Only issues after this date will


### PR DESCRIPTION
I saw the `sort` parameter in Github's documentation, but was wondering where it was in github3.py.  It turns out it's there, both supported and documented, but the doc line was mistakenly merged into the previous line, which makes it easy to miss.

Now it should be more hunky-dory.
