### PR TITLE
Mock isn't supported on python 3.4

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -60,3 +60,5 @@ Contributors
 - Philip Chimento (@ptomato)
 
 - Benjamin Gilbert (@bgilbert)
+
+- Daniel Johnson (@danielj7)

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,11 @@ packages = [
     "github3.search",
 ]
 
-kwargs['tests_require'] = ['mock == 1.0.1', 'betamax >=0.1.6', 'pytest']
+kwargs['tests_require'] = ['betamax >=0.1.6', 'pytest']
 if sys.version_info < (3, 0):
     kwargs['tests_require'].append('unittest2==0.5.1')
+if sys.version_info < (3, 3):
+    kwargs['tests_require'].append('mock == 1.0.1')
 
 if sys.argv[-1] in ("submit", "publish"):
     os.system("python setup.py bdist_wheel sdist upload")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,9 @@
 import github3
 from unittest import TestCase
-from mock import patch, NonCallableMock
+try:
+   from unittest.mock import patch, NonCallableMock
+except ImportError:
+   from mock import patch, NonCallableMock
 
 
 class TestAPI(TestCase):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,5 +1,8 @@
 import github3
-from mock import patch, Mock
+try:
+   from unittest.mock import patch, Mock
+except ImportError:
+   from mock import patch, Mock
 from tests.utils import (BaseCase, load)
 
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -6,7 +6,10 @@ from github3.issues.milestone import Milestone
 from github3.issues import Issue
 import datetime
 from tests.utils import BaseCase, load
-from mock import patch
+try:
+   from unittest.mock import patch
+except ImportError:
+   from mock import patch
 
 
 class TestLabel(BaseCase):

--- a/tests/test_orgs.py
+++ b/tests/test_orgs.py
@@ -1,5 +1,8 @@
 import github3
-from mock import patch, Mock
+try:
+   from unittest.mock import patch, Mock
+except ImportError:
+   from mock import patch, Mock
 from tests.utils import BaseCase, load
 
 

--- a/tests/test_pulls.py
+++ b/tests/test_pulls.py
@@ -1,5 +1,8 @@
 import github3
-from mock import patch
+try:
+   from unittest.mock import patch
+except ImportError:
+   from mock import patch
 from tests.utils import BaseCase, load
 
 

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -3,7 +3,10 @@ import github3
 from github3 import repos
 from datetime import datetime
 from tests.utils import (BaseCase, load)
-from mock import patch, mock_open
+try:
+   from unittest.mock import patch, mock_open
+except ImportError:
+   from mock import patch, mock_open
 
 
 class TestRepository(BaseCase):

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -1,7 +1,10 @@
 import github3
 from github3.structs import GitHubIterator
 from tests.utils import BaseCase
-from mock import patch
+try:
+   from unittest.mock import patch
+except ImportError:
+   from mock import patch
 
 
 class TestGitHubIterator(BaseCase):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,5 +1,8 @@
 import github3
-from mock import patch
+try:
+   from unittest.mock import patch
+except ImportError:
+   from mock import patch
 from tests.utils import (BaseCase, load)
 from datetime import datetime
 

--- a/tests/unit/helper.py
+++ b/tests/unit/helper.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import github3
 import unittest
 

--- a/tests/unit/test_github_session.py
+++ b/tests/unit/test_github_session.py
@@ -3,7 +3,10 @@ import pytest
 import requests
 
 from github3 import session
-from mock import patch, Mock
+try:
+   from unittest.mock import patch, Mock
+except ImportError:
+   from mock import patch, Mock
 
 
 class TestGitHubSession:

--- a/tests/unit/test_structs.py
+++ b/tests/unit/test_structs.py
@@ -1,7 +1,10 @@
 from .helper import UnitHelper
 from github3.structs import GitHubIterator
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestGitHubIterator(UnitHelper):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,10 @@ else:
 
 import requests
 import github3
-from mock import patch
+try:
+   from unittest.mock import patch
+except ImportError:
+   from mock import patch
 from io import BytesIO
 from requests.structures import CaseInsensitiveDict
 


### PR DESCRIPTION
It is included in unittest starting with 3.3.
Change tests to try importing unittest.mock first, then falling back to mock.
Change setup.py to only require mock for tests on python < 3.3.
All tests pass on 3.4 with this change.
