### PR TITLE
Update documentation of Github.create_issue

### DIFF
--- a/github3/github.py
+++ b/github3/github.py
@@ -180,10 +180,13 @@ class GitHub(GitHubCore):
             formatted
         :param str assignee: (optional), Login of person to assign
             the issue to
-        :param str milestone: (optional), Which milestone to assign
-            the issue to
+        :param int milestone: (optional), id number of the milestone to
+            attribute this issue to (e.g. ``m`` is a :class:`Milestone
+            <github3.issues.Milestone>` object, ``m.number`` is what you pass
+            here.)
         :param list labels: (optional), List of label names.
-        :returns: :class:`Issue <github3.issues.Issue>`
+        :returns: :class:`Issue <github3.issues.Issue>` if successful, else
+            None
         """
         repo = None
         if owner and repository and title:


### PR DESCRIPTION
copy and paste from Repository.create_issue.

The docstring of Github.create_issue and  Repository.create_issue still differs, but at least the important things should be fixed now.

Perhaps there is a way to keep them in sync without the need of copy and paste? For example only document params `owner` and `repository` and include a link to Repositroy.create_issue. As I'm very new to github3.py I did not realize that Github.create_issue is only a shorthand for Repository.create_issue.
