### PR TITLE
Adding support for calling URL with invalid SSL cert

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -62,3 +62,5 @@ Contributors
 - Benjamin Gilbert (@bgilbert)
 
 - Daniel Johnson (@danielj7)
+
+- David Moss (@damoss007)

--- a/github3/github.py
+++ b/github3/github.py
@@ -1459,10 +1459,14 @@ class GitHubEnterprise(GitHub):
 
     There is no need to provide the end of the url (e.g., /api/v3/), that will
     be taken care of by us.
+    
+    If you have a self signed SSL for your local github enterprise you can 
+    override the validation by passing `verify=False`.
     """
-    def __init__(self, url, login='', password='', token=''):
+    def __init__(self, url, login='', password='', token='', verify=True):
         super(GitHubEnterprise, self).__init__(login, password, token)
         self._session.base_url = url.rstrip('/') + '/api/v3'
+        self._session.verify = verify
 
     def _repr(self):
         return '<GitHub Enterprise [0.url]>'.format(self)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,4 +1,5 @@
 import github3
+
 from tests.utils import (BaseCase, load, mock)
 
 
@@ -850,6 +851,19 @@ class TestGitHubEnterprise(BaseCase):
         assert 'data' in kwargs
         assert body == kwargs['data']
         self.mock_assertions()
+
+
+class TestUnsecureGitHubEnterprise(BaseCase):
+    def setUp(self):
+        super(TestUnsecureGitHubEnterprise, self).setUp()
+        self.g = github3.GitHubEnterprise('https://github.example.com:8080/', verify=False)
+    
+    def test_skip_ssl_validation(self):
+        self.response('pull_enterprise')
+        self.g.pull_request('sigmavirus24', 'github3.py', 19)
+        
+        assert False == self.g._session.verify
+        assert self.request.called
 
 
 class TestGitHubStatus(BaseCase):


### PR DESCRIPTION
When hosting GitHubEnterprise internally there's a greater chance the SSL certificate could be self signed and thus you need to prevent the requests library from validating the SSL certificate. By passing the verify flag through you can control this validation check and prevent:

 `SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed`
