### PR TITLE
Fix typo in Repository JSON key 'forks_count'

### DIFF
--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -71,7 +71,7 @@ class Repository(GitHubCore):
         self.forks = repo.get('forks', 0)
 
         #: The number of forks of this repository.
-        self.fork_count = repo.get('fork_count')
+        self.forks_count = repo.get('forks_count')
 
         #: Is this repository a fork?
         self.fork = repo.get('fork')


### PR DESCRIPTION
It should be 'forks_count' instead of 'fork_count' according to https://developer.github.com/v3/repos/#get.
