### PR TITLE
tests pass

### DIFF
--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -46,6 +46,8 @@ class CustomHeadersMatcher(betamax.BaseMatcher):
         recorded_request['headers'].pop('User-Agent', None)
         request.headers.pop('Accept-Encoding', None)
         recorded_request['headers'].pop('Accept-Encoding', None)
+        request.headers.pop('Connection', None)
+        recorded_request['headers'].pop('Connection', None)
         return self.headers_matcher.match(request, recorded_request)
 
 


### PR DESCRIPTION
pulled from 106e0a3e28ebd6570fcdd5e6ca698eafb361d3c8 on 1.0-alpha branch
