### PR TITLE
Make create_tree without base_tree work again

### DIFF
--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -843,7 +843,9 @@ class Repository(GitHubCore):
         """
         json = None
         if tree and isinstance(tree, list):
-            data = {'tree': tree, 'base_tree': base_tree}
+            data = {'tree': tree}
+            if base_tree:
+                data['base_tree'] = base_tree
             url = self._build_url('git', 'trees', base_url=self._api)
             json = self._json(self._post(url, data=data), 201)
         return Tree(json) if json else None


### PR DESCRIPTION
GitHub now sends an error when specifying an empty base_tree, so let's
not provide it at all if it's empty.
