### PR TITLE
Use separate session to download assets from AWS

### DIFF
--- a/github3/repos/release.py
+++ b/github3/repos/release.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import json
-import requests
 
+from ..session import GitHubSession
 from ..decorators import requires_auth
 from ..models import GitHubCore, GitHubError
 from ..utils import stream_response_to_file
@@ -189,7 +189,7 @@ class Asset(GitHubCore):
                 'Authorization': None,
                 'Content-Type': None,
                 })
-            resp = requests.Session().get(resp.headers['location'], stream=True,
+            resp = GitHubSession().get(resp.headers['location'], stream=True,
                              headers=headers)
 
         if self._boolean(resp, 200, 404):


### PR DESCRIPTION
This fixes an error "Only one auth mechanism allowed; only the X-Amz-Algorithm query parameter, Signature query string parameter or the Authorization header should be specified" which occurs when downloading asset for the release.

The easiest fix is to use another Session as clearing headers doesn't work properly.

Steps to reproduce an issue:
- Create repository, push tag 'v1' and create a release for that tag
- Upload asset (for example 'build.tar.gz')
- Try to use following code to download that asset

``` python

import github3

github = github3.login('username', 'password')
repository = github.repository('repository_owner', 'repository_name')

for release in repository.iter_releases():
    if release.tag_name == 'v1':
        for asset in release.assets:
            if asset.name == 'build.tar.gz':
                asset.download()

```
