### PR TITLE
tox.ini: Use py.test directly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,24 @@
 [tox]
-envlist = py26,py27,py32,py33,py34
+envlist = py26, py27, py32, py33, py34
+
 [testenv]
-deps = 
-    requests>=1.2.3 
-    coverage>=3.5.2 
+deps =
+    requests>=1.2.3
+    coverage>=3.5.2
     mock>=1.0.1
-commands = 
-    python setup.py test
+    pytest>=2.6.4
+    betamax>=0.4.1
+    unittest2>=0.5.1
+commands =
+    py.test {posargs:-q tests/}
 
 [testenv:py26]
-deps = 
-    requests>=1.2.3 
-    coverage>=3.5.2 
+deps =
+    requests>=1.2.3
+    coverage>=3.5.2
     mock>=1.0.1
-commands = 
-    python setup.py test
-
-[pytest]
-addopts = -q tests/
+    pytest>=2.6.4
+    betamax>=0.4.1
+    unittest2>=0.5.1
+commands =
+    py.test {posargs:-q tests/}


### PR DESCRIPTION
instead of `python setup.py test`.

The advantage of using `py.test` directly is that you can now pass `py.test` options to take advantage of all of its neat features for controlling test collection, output control, pdb, etc. E.g.:

```
tox -e py27 -- --tb=short --pdb --pyargs tests.integration.test_repos_release -k test_download
```

I also did some minor formatting cleanup, like removing whitespace from ends of lines and putting spaces after commas in the `envlist`.

This is partly what I subjectively prefer and partly that my vim config lights up extra spaces at the ends of lines like a Christmas tree :-). If you don't like some of it, I can split it out so you can cherry-pick.
