### PR TITLE
tox.ini: use py.test directly instead of python setup.py test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,4 +39,5 @@ deps =
 commands = flake8 github3/
 
 [pytest]
-addopts = -q tests/
+addopts = -q
+norecursedirs = *.egg .git .* _*


### PR DESCRIPTION
This is a similar change to #292, but based on the branch in #293 (brings over `tox.ini` changes from @sigmavirus24 on the `1.0-alpha` branch).

```
$ tox -e py27
GLOB sdist-make: /Users/marca/dev/git-repos/github3.py/setup.py
py27 inst-nodeps: /Users/marca/dev/git-repos/github3.py/.tox/dist/github3.py-0.9.2.zip
py27 runtests: PYTHONHASHSEED='2339110401'
py27 runtests: commands[0] | py.test -q tests/
..............................................x...............................................................................................................................................................................................................................................................................................................................................................................................................................................................
493 passed, 1 xfailed in 3.79 seconds
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py27: commands succeeded
  congratulations :)

$ tox -e py27 -- --tb=short --pdb --pyargs tests.integration.test_repos_release -k test_download
GLOB sdist-make: /Users/marca/dev/git-repos/github3.py/setup.py
py27 inst-nodeps: /Users/marca/dev/git-repos/github3.py/.tox/dist/github3.py-0.9.2.zip
py27 runtests: PYTHONHASHSEED='3359558432'
py27 runtests: commands[0] | py.test --tb=short --pdb --pyargs tests.integration.test_repos_release -k test_download
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 6 items

tests/integration/test_repos_release.py .

=================================================================== 5 tests deselected by '-ktest_download' ====================================================================
==================================================================== 1 passed, 5 deselected in 0.09 seconds ====================================================================
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```
