### PR TITLE
Simplify tox.ini; always require unittest2>=0.6.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,7 @@ envlist = py26,py27,py32,py33,py34,pypy,{py27,py34}-flake8
 pip_pre = False
 deps =
     -rdev-requirements.txt
-    pypy: unittest2
-    py26: unittest2
-    py27: unittest2
+    unittest2>=0.6.0
 commands = py.test {posargs}
 
 [testenv:py27-flake8]


### PR DESCRIPTION
I **think** this simplification will work, because unittest2>=0.6.0 won't fail to install on Python 3. 

That said, this is untested as I'm on an iPhone and kind of fluey, so caveat emptor!
