### PR TITLE
tox.ini: Tweak test discovery

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,25 +4,25 @@ envlist = py26,py27,py32,py33,py34,pypy,{py27,py34}-flake8
 [testenv]
 pip_pre = False
 deps = -rdev-requirements.txt
-commands = py.test
+commands = py.test {posargs}
 
 [testenv:pypy]
 deps =
     -rdev-requirements.txt
     unittest2
-commands = py.test
+commands = py.test {posargs}
 
 [testenv:py26]
 deps =
     -rdev-requirements.txt
     unittest2
-commands = py.test
+commands = py.test {posargs}
 
 [testenv:py27]
 deps =
     -rdev-requirements.txt
     unittest2
-commands = py.test
+commands = py.test {posargs}
 
 [testenv:py27-flake8]
 basepython = python2.7


### PR DESCRIPTION
Replace `tests/` in `addopts` with `norecursedirs`

Better to filter than to add in a default, so as not to force folks to always run all the tests.

This is motivated by the comments on another PR: https://github.com/sigmavirus24/github3.py/pull/294#discussion_r19709451

Note that the `norecursedirs` line might not even be necessary as `pytest` has fairly comprehensive defaults that might already handle the stuff that you're worried about. See http://pytest.org/latest/customize.html#confval-norecursedirs

Proof that it works:

```
$ tox -e py27 -- -v tests/integration/test_repos_release.py
GLOB sdist-make: /Users/marca/dev/git-repos/github3.py/setup.py
py27 inst-nodeps: /Users/marca/dev/git-repos/github3.py/.tox/dist/github3.py-0.9.2.zip
py27 runtests: PYTHONHASHSEED='2770156593'
py27 runtests: commands[0] | py.test -v tests/integration/test_repos_release.py
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 6 items

tests/integration/test_repos_release.py ......

=========================================================================== 6 passed in 0.28 seconds ===========================================================================
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```

```
$ tox -e py27
GLOB sdist-make: /Users/marca/dev/git-repos/github3.py/setup.py
py27 inst-nodeps: /Users/marca/dev/git-repos/github3.py/.tox/dist/github3.py-0.9.2.zip
py27 runtests: PYTHONHASHSEED='2676834291'
py27 runtests: commands[0] | py.test
..............................................x...............................................................................................................................................................................................................................................................................................................................................................................................................................................................
493 passed, 1 xfailed in 3.85 seconds
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```

Closes #294.
