### PR TITLE
tox.ini: Tweak test discovery

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,5 @@ deps =
 commands = flake8 {posargs} github3/
 
 [pytest]
-addopts = -q tests/
+addopts = -q
+norecursedirs = *.egg .git .* _*


### PR DESCRIPTION
Replace `tests/` in `addopts` with `norecursedirs`

Better to filter than to add in a default, so as not to force folks to always run all the tests.

This is the same as #296, but applied to the `1.0-alpha` branch.
