### PR TITLE
Make "s" in "https" optional to match URL w/ regex

### DIFF
--- a/github3/github.py
+++ b/github3/github.py
@@ -1000,7 +1000,7 @@ class GitHub(GitHubCore):
         :returns: bool
         """
         from re import match
-        m = match('https://[\w\d\-\.\:]+/\w+/[\w\._-]+/events/\w+', topic)
+        m = match('https?://[\w\d\-\.\:]+/\w+/[\w\._-]+/events/\w+', topic)
         status = False
         if mode and topic and callback and m:
             data = [('hub.mode', mode), ('hub.topic', topic),

--- a/github3/issues/issue.py
+++ b/github3/issues/issue.py
@@ -77,7 +77,7 @@ class Issue(GitHubCore):
         self.number = issue.get('number')
         #: Dictionary URLs for the pull request (if they exist)
         self.pull_request = issue.get('pull_request')
-        m = match('https://[\w\d\-\.\:]+/(\S+)/(\S+)/(?:issues|pull)/\d+',
+        m = match('https?://[\w\d\-\.\:]+/(\S+)/(\S+)/(?:issues|pull)/\d+',
                   self.html_url)
         #: Returns ('owner', 'repository') this issue was filed on.
         self.repository = m.groups()

--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -183,7 +183,7 @@ class PullRequest(GitHubCore):
         #: GitHub.com url for review comments (not a template)
         self.review_comments_url = pull.get('review_comments_url')
 
-        m = match('https://[\w\d\-\.\:]+/(\S+)/(\S+)/(?:issues|pull)?/\d+',
+        m = match('https?://[\w\d\-\.\:]+/(\S+)/(\S+)/(?:issues|pull)?/\d+',
                   self.issue_url)
         #: Returns ('owner', 'repository') this issue was filed on.
         self.repository = m.groups()


### PR DESCRIPTION
Some folks may be using a GitHub Enterprise server that doesn't support HTTPS.

Without this fix, I get errors when trying to use github-cli with our non-HTTPS-enabled GitHub Enterprise server.

```
$ gh -r devmonkeys/smstack issue.ls
Traceback (most recent call last):
  File "/Users/marca/python/virtualenvs/github-cli/bin/gh", line 9, in <module>
    load_entry_point('gh-cli==0.1.b', 'console_scripts', 'gh')()
  File "/Users/marca/dev/git-repos/github-cli/gh/main.py", line 29, in main
    status = commands[command].run(opts, args[1:])
  File "/Users/marca/dev/git-repos/github-cli/gh/commands/issue/ls.py", line 56, in run
    return self.print_issues(opts)
  File "/Users/marca/dev/git-repos/github-cli/gh/commands/issue/ls.py", line 86, in print_issues
    for i in issues:
  File "/Users/marca/python/virtualenvs/github-cli/lib/python2.7/site-packages/github3/structs.py", line 82, in __iter__
    yield cls(i, self) if issubclass(cls, GitHubCore) else cls(i)
  File "/Users/marca/python/virtualenvs/github-cli/lib/python2.7/site-packages/github3/issues/issue.py", line 83, in __init__
    self.repository = m.groups()
AttributeError: 'NoneType' object has no attribute 'groups'
```
