### PR TITLE
GitHubEnterprise: Add url attribute; show in _repr

### DIFF
--- a/github3/github.py
+++ b/github3/github.py
@@ -1491,9 +1491,10 @@ class GitHubEnterprise(GitHub):
         super(GitHubEnterprise, self).__init__(login, password, token)
         self._session.base_url = url.rstrip('/') + '/api/v3'
         self._session.verify = verify
+        self.url = url
 
     def _repr(self):
-        return '<GitHub Enterprise [0.url]>'.format(self)
+        return '<GitHub Enterprise [{0.url}]>'.format(self)
 
     @requires_auth
     def admin_stats(self, option):


### PR DESCRIPTION
Without this PR, it's not easy to get the `url` from a `GitHubEnterprise` object. With it, there is a URL attribute. Also the output of `_repr` has been improved.
#### Without this PR:

```
In [1]: import github3

In [2]: github = github3.GitHubEnterprise('http://github.mycompany.com')

In [3]: github
Out[3]: <GitHub Enterprise [0.url]>
```

The `"0.url"` in the above output isn't terribly useful. It looks like an attempt was made to show the URL, but it got messed up.
#### With this PR:

```
In [1]: import github3

In [2]: github = github3.GitHubEnterprise('http://github.mycompany.com')

In [3]: github
Out[3]: <GitHub Enterprise [http://github.mycompany.com]>
```
