### PR TITLE
Fix GH-304: Check for tag is None

### DIFF
--- a/github3/repos/tag.py
+++ b/github3/repos/tag.py
@@ -19,6 +19,8 @@ class RepoTag(GitHubObject):
     """
     def __init__(self, tag):
         super(RepoTag, self).__init__(tag)
+        if tag is None:
+            return
         #: Name of the tag.
         self.name = tag.get('name')
         #: URL for the GitHub generated zipball associated with the tag.


### PR DESCRIPTION
`github3/repos/tag.py`: Check for `tag is None` in `RepoTag.__init__`

Fixes: GH-304 (https://github.com/sigmavirus24/github3.py/issues/304)
