### PR TITLE
PullRequest.commits returns generator of RepoCommits

### DIFF
--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 
 from re import match
 from json import dumps
-from .git import Commit
+from .repos.commit import RepoCommit
 from .models import GitHubObject, GitHubCore, BaseComment
 from .users import User
 from .decorators import requires_auth
@@ -238,10 +238,11 @@ class PullRequest(GitHubCore):
             -1 returns all available commits.
         :param str etag: (optional), ETag from a previous request to the same
             endpoint
-        :returns: generator of :class:`Commit <github3.git.Commit>`\ s
+        :returns: generator of
+            :class:`RepoCommit <github3.repos.commit.RepoCommit>`\ s
         """
         url = self._build_url('commits', base_url=self._api)
-        return self._iter(int(number), url, Commit, etag=etag)
+        return self._iter(int(number), url, RepoCommit, etag=etag)
 
     def files(self, number=-1, etag=None):
         r"""Iterate over the files associated with this pull request.

--- a/tests/integration/test_pulls.py
+++ b/tests/integration/test_pulls.py
@@ -31,7 +31,7 @@ class TestPullRequest(IntegrationHelper):
         with self.recorder.use_cassette(cassette_name):
             p = self.get_pull_request()
             for commit in p.commits():
-                assert isinstance(commit, github3.git.Commit)
+                assert isinstance(commit, github3.repos.commit.RepoCommit)
 
     def test_create_review_comment(self):
         """Show that a user can create an in-line reveiw comment on a PR."""


### PR DESCRIPTION
Related: #253 

Return a generator of `RepoCommit`s instead of `Commit`s as this matches the API structure better and will allow the caller to retrieve the message using `commit.commit.message`

Left the `last_modified` field alone since that seems to be based in the headers and belong to the top level of a json structure.

Updated tests and docs.
