### PR TITLE
Add tox env for releasing the project

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,9 @@ commands = flake8 {posargs} github3/ tests/unit/ tests/integration/
 [testenv:release]
 deps =
     twine >= 1.4.0
+    wheel
 commands =
-    python setup.py sdist
-    pip wheel --wheel-dir dist/
+    python setup.py sdist bdist_wheel
     twine upload {posargs} dist/*
 
 [pytest]


### PR DESCRIPTION
Problems so far:
- https://github.com/pypa/twine/issues/65 because tox doesn't run the commands in a way that allows for globbing
