### PR TITLE
Repository.permissions attribute support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,3 +84,5 @@ Contributors
 - Bryce Boe (@bboe)
 
 - Ryan Weald (@rweald)
+
+- Lars Holm Nielsen (@larshankat)

--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -127,6 +127,10 @@ class Repository(GitHubCore):
 
         #: Is this repository private?
         self.private = repo.get('private')
+
+        #: Permissions for this repository
+        self.permissions = repo.get('permissions')
+
         #: ``datetime`` object representing the last time commits were pushed
         #: to the repository.
         self.pushed_at = self._strptime(repo.get('pushed_at'))

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -507,6 +507,12 @@ class TestRepository(BaseCase):
         r = repos.Repository(json)
         assert isinstance(r.parent, repos.Repository)
 
+    def test_permissions(self):
+        json = load('repo')
+        permissions = {"admin": True, "push": True, "pull": True}
+        assert json['permissions'] == permissions
+        assert self.repo.permissions == permissions
+
     def test_pull_request(self):
         self.response('pull', 200)
         self.get(self.api + 'pulls/2')


### PR DESCRIPTION
* Adds support for accessing permissions attribute of a repository.
  This is needed to enable filtering a users repositories based on
  admin, push and pull permissions (addresses zenodo/zenodo#135).