### PR TITLE
Rate limit independent request counter

### DIFF
--- a/github3/session.py
+++ b/github3/session.py
@@ -35,6 +35,7 @@ class GitHubSession(requests.Session):
             })
         self.base_url = 'https://api.github.com'
         self.two_factor_auth_cb = None
+        self.request_counter = 0
 
     def basic_auth(self, username, password):
         """Set the Basic Auth credentials on this Session.
@@ -85,6 +86,7 @@ class GitHubSession(requests.Session):
 
     def request(self, *args, **kwargs):
         response = super(GitHubSession, self).request(*args, **kwargs)
+        self.request_counter += 1
         if requires_2fa(response) and self.two_factor_auth_cb:
             # No need to flatten and re-collect the args in
             # handle_two_factor_auth


### PR DESCRIPTION
using `g.rate_limit()` is perfectly fine when using a single thread/process application to guage how many requests have been made by a certain set of methods, but once you use more than one instance of `GithubSession` at a time it becomes somewhat useless since you can't measure the start/end points as they are moving.

I've added an *extremely simple* workaround for this which is storing a request counter (`GithubSession.request_counter`) that gets incremented every time `GithubSession.request()` is called allowing measurement of requests made independent of other instances of `GithubSession` using the same credentials.

With the current commit the only way to access this is by calling the somewhat long winded `Github.__dict__["session"].__dict__["request_counter"]` but I left it at that before getting your opinion on a better way for this to be easily accessible.