### PR TITLE
Clarify use of a personal access token with login()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@ htmlcov/
 .tox/
 venv/
 venv*/
+.venv/
 build/
 *.egg
+.eggs/
 .env
 .ipynb_checkpoints

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -88,3 +88,5 @@ Contributors
 - Lars Holm Nielsen (@larshankat)
 
 - Ryan Pitts (@ryanpitts)
+
+- Jürgen Hermann (@jhermann)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ COVERAGE_INCLUDE := github3/*.py
 TEST_RUNNER := python setup.py test
 
 .DEFAULT_GOAL := tests
+.PHONY: clean travis tests test-deps htmlcov docs
+
 
 clean:
 	git clean -Xdf

--- a/github3/__init__.py
+++ b/github3/__init__.py
@@ -33,7 +33,7 @@ from .exceptions import (
 
 __all__ = (
     'AuthenticationFailed',  'BadRequest', 'ForbiddenError', 'GitHub',
-    'GitHubEnterprise', 'GitHubError', 'GitHubStatus', 'InvalidRequestError',
+    'GitHubEnterprise', 'GitHubError', 'GitHubStatus',
     'MethodNotAllowed', 'NotAcceptable', 'NotFoundError', 'ServerError',
     'UnprocessableEntity', 'authorize', 'login', 'enterprise_login', 'emojis',
     'gist', 'gitignore_template', 'create_gist', 'issue', 'markdown',

--- a/github3/github.py
+++ b/github3/github.py
@@ -52,6 +52,9 @@ class GitHub(GitHubCore):
 
     This is simple backward compatibility since originally there was no way to
     call the GitHub object with authentication parameters.
+
+    Note that a *Personal access token* needs to be passed as ``password``,
+    not as a ``token``.
     """
 
     def __init__(self, username='', password='', token=''):

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import sys


### PR DESCRIPTION
Also fixing a bug in `__all__` of github3 (exported symbol
that is defined nowhere), and adding .PHONY to the Makefile,
so `make docs` works reliably.

NB: You should consider adding Sphinx to dev-requirements, since an "external" Sphinx is unlikely to have `uritemplate.py` in its Python path. I had to add it to the venv after `make docs` error'd out.