### PR TITLE
readme: install the pre version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Installation
 
 ::
 
-    $ pip install github3.py
+    $ pip install --pre github3.py
 
 Dependencies
 ------------


### PR DESCRIPTION
The latest released version is a pre-released version. It's confusing to install the latest release pip version and the docs seeming out of sync.

Alternative could be to tell users to install via 'rm dist/* && python setup.py sdist && pip install dist/*.tar.gz'.