### PR TITLE
fixes sigmavirus24/github3.py/issues/378

### DIFF
--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -1005,7 +1005,7 @@ class Repository(GitHubCore):
             url = self._build_url('git', 'tags', base_url=self._api)
             json = self._json(self._post(url, data=data), 201)
             if json:
-                self.create_ref('refs/tags/' + tag, sha)
+                self.create_ref('refs/tags/' + tag, json['sha'])
         return self._instance_or_null(Tag, json)
 
     @requires_auth


### PR DESCRIPTION
This fixes a failure of create_tag to create annotated tags as
documented.

The created reference should be the SHA of the created tag object, not
the original tagged commit.