### PR TITLE
Add params support to Issue.comments()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -90,3 +90,5 @@ Contributors
 - Ryan Pitts (@ryanpitts)
 
 - Jürgen Hermann (@jhermann)
+
+- Antoine Giraudmaillet (@antoine-g)

--- a/github3/issues/comment.py
+++ b/github3/issues/comment.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from ..utils import timestamp_parameter
 from ..models import BaseComment
 from ..users import User
 
@@ -36,3 +37,19 @@ class IssueComment(BaseComment):
 
     def _repr(self):
         return '<Issue Comment [{0}]>'.format(self.user.login)
+
+
+def issue_comment_params(sort, direction, since):
+    params = {}
+
+    if sort in ('created', 'updated'):
+        params['sort'] = sort
+
+    if direction in ('asc', 'desc'):
+        params['direction'] = direction
+
+    since = timestamp_parameter(since)
+    if since:
+        params['since'] = since
+
+    return params

--- a/github3/issues/issue.py
+++ b/github3/issues/issue.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from re import match
 from json import dumps
 from ..decorators import requires_auth
-from .comment import IssueComment
+from .comment import IssueComment, issue_comment_params
 from .event import IssueEvent
 from .label import Label
 from .milestone import Milestone
@@ -155,15 +155,25 @@ class Issue(GitHubCore):
             json = self._json(self._get(url), 200)
         return self._instance_or_null(IssueComment, json)
 
-    def comments(self, number=-1):
-        r"""Iterate over the comments on this issue.
+    def comments(self, number=-1, sort='', direction='', since=None):
+        """Iterate over the comments on this issue.
 
         :param int number: (optional), number of comments to iterate over
+            Default: -1 returns all comments
+        :param str sort: accepted valuees: ('created', 'updated')
+            api-default: created
+        :param str direction: accepted values: ('asc', 'desc')
+            Ignored without the sort parameter
+        :param since: (optional), Only issues after this date will
+            be returned. This can be a `datetime` or an ISO8601 formatted
+            date string, e.g., 2012-05-20T23:10:27Z
+        :type since: datetime or string
         :returns: iterator of
             :class:`IssueComment <github3.issues.comment.IssueComment>`\ s
         """
         url = self._build_url('comments', base_url=self._api)
-        return self._iter(int(number), url, IssueComment)
+        params = issue_comment_params(sort, direction, since)
+        return self._iter(int(number), url, IssueComment, params)
 
     @requires_auth
     def create_comment(self, body):


### PR DESCRIPTION
GitHub API v3 supports some parameters which are not supported in github3.py for retrieving comments associated with an issue. These are documented at https://developer.github.com/v3/issues/comments/#list-comments-in-a-repository.

Following the implementation of `issue_params()`, a new method `issue_comment_params()` has been added to process the params values.
It now supports the following parameters:
 - sort
 - direction
 - since

No integration test was added on this particular feature because params are currently not part of the test framework (i.e. `GitHub.issues()`). This is arguable.

GitHub API documentation is unclear regarding the default sorting direction if no value is given. It turns out that the results are returned in ascending order. I did not document this in the docstring as it might change without notice.

Comments are welcome.