### PR TITLE
Call out proper name of module in import statent

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -165,7 +165,7 @@ enterprise installation, e.g.
 
 ::
 
-    from github import GitHubEnterprise
+    from github3 import GitHubEnterprise
 
     g = GitHubEnterprise('https://github.examplesintl.com')
     stats = g.admin_stats('all')


### PR DESCRIPTION
added the missing "3" at the end of the import statement in the GitHub Enterprise section