### PR TITLE
Fix exception when merging with empty commit message

### DIFF
--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -313,9 +313,7 @@ class PullRequest(models.GitHubCore):
             merge commit
         :returns: bool
         """
-        data = None
-        if commit_message:
-            data = dumps({'commit_message': commit_message})
+        data = dumps({'commit_message': commit_message})
         url = self._build_url('merge', base_url=self._api)
         json = self._json(self._put(url, data=data), 200)
         if not json:

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -67,7 +67,9 @@ class TestPullRequest(UnitHelper):
         """Show that a user can merge a Pull Request."""
         self.instance.merge()
 
-        self.session.put.assert_called_once_with(url_for('merge'), data=None)
+        self.session.put.assert_called_once_with(
+	    url_for('merge'),
+	    data='{"commit_message": ""}')
 
     def test_patch(self):
         """Show that a user can fetch the patch from a Pull Request."""


### PR DESCRIPTION
Fixes https://github.com/sigmavirus24/github3.py/issues/370

As I also experienced the error and the issue has not been active for 2 weeks, I thought I would submit a PR. Feel free to accept or reject this fix. It may conflict with #381.

The GitHub API now requires a param `commit_message` with an empty value when merging a pull request. In such case the default value is used as a commit message.
Providing an empty data string no longer works.