### PR TITLE
Fix exception when merging with empty commit message (backport)

### DIFF
--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -307,9 +307,7 @@ class PullRequest(GitHubCore):
             merge commit
         :returns: bool
         """
-        data = None
-        if commit_message:
-            data = dumps({'commit_message': commit_message})
+        data = dumps({'commit_message': commit_message})
         url = self._build_url('merge', base_url=self._api)
         json = self._json(self._put(url, data=data), 200)
         self.merge_commit_sha = json['sha']

--- a/tests/test_pulls.py
+++ b/tests/test_pulls.py
@@ -107,7 +107,7 @@ class TestPullRequest(BaseCase):
     def test_merge(self):
         self.response('merge', 200)
         self.put(self.api + '/merge')
-        self.conf = {'data': None}
+        self.conf = {'data': {'commit_message': ''}}
 
         self.assertRaises(github3.GitHubError, self.pull.merge)
 


### PR DESCRIPTION
This pull-request backports #390 to `stable/0.9`.

----
Commit message:
Fixes https://github.com/sigmavirus24/github3.py/issues/370

The GitHub API now requires a param `commit_message` with an empty value when merging a pull request. In such case the default value is used as a commit message.
Providing an empty data string no longer works.

(cherry picked from commit 39c06c94267b7416d2455c8676cb012a3a0335a2)

Conflicts:
	tests/unit/test_pulls.py

The test file was not backported because it doesn't exist on the destination branch.