### PR TITLE
contents method should be used at the place of file_contents.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -92,3 +92,5 @@ Contributors
 - Jürgen Hermann (@jhermann)
 
 - Antoine Giraudmaillet (@antoine-g)
+
+- Chandan Kumar (@chkumar246)

--- a/example-notebooks/contents-api.ipynb
+++ b/example-notebooks/contents-api.ipynb
@@ -1,612 +1,637 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:2a5438fc20dfd72328eb42f08327a4c176de03fe0009f6a33ecd15f27d7f51df"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Contents API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieving a File's Contents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import github3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "repo = github3.repository('sigmavirus24', 'github3.py')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "contents = repo.contents('github3/repos/contents.py')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have the contents of the file at `github3/repos/contents.py` we can get information about it. We can find the name, the SHA of the commit that most recently updated it, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Contents API"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "contents.py\n"
      ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Retrieving a File's Contents"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import github3"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "repo = github3.repository('sigmavirus24', 'github3.py')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "contents = repo.file_contents('github3/repos/contents.py')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now that we have the contents of the file at `github3/repos/contents.py` we can get information about it. We can find the name, the SHA of the commit that most recently updated it, etc."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(contents.name)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "contents.py\n"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(contents.sha)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "ec9f27e0cc18a5440952ebb7dc9b3b9402b93702\n"
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We can also get the contents of the file:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(contents.content)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "IyAtKi0gY29kaW5nOiB1dGYtOCAtKi0KIiIiCmdpdGh1YjMucmVwb3MuY29u\n",
-        "dGVudHMKPT09PT09PT09PT09PT09PT09PT09PQoKVGhpcyBtb2R1bGUgY29u\n",
-        "dGFpbnMgdGhlIENvbnRlbnRzIG9iamVjdCBwZXJ0YWluaW5nIHRvIFJFQURN\n",
-        "RXMgYW5kIG90aGVyIGZpbGVzCnRoYXQgY2FuIGJlIGFjY2Vzc2VkIHZpYSB0\n",
-        "aGUgR2l0SHViIEFQSS4KCiIiIgpmcm9tIF9fZnV0dXJlX18gaW1wb3J0IHVu\n",
-        "aWNvZGVfbGl0ZXJhbHMKCmZyb20ganNvbiBpbXBvcnQgZHVtcHMKZnJvbSBi\n",
-        "YXNlNjQgaW1wb3J0IGI2NGRlY29kZSwgYjY0ZW5jb2RlCmZyb20gLi5naXQg\n",
-        "aW1wb3J0IENvbW1pdApmcm9tIC4ubW9kZWxzIGltcG9ydCBHaXRIdWJDb3Jl\n",
-        "CmZyb20gLi5kZWNvcmF0b3JzIGltcG9ydCByZXF1aXJlc19hdXRoCgoKY2xh\n",
-        "c3MgQ29udGVudHMoR2l0SHViQ29yZSk6CiAgICAiIiJUaGUgOmNsYXNzOmBD\n",
-        "b250ZW50cyA8Q29udGVudHM+YCBvYmplY3QuIEl0IGhvbGRzIHRoZSBpbmZv\n",
-        "cm1hdGlvbgogICAgY29uY2VybmluZyBhbnkgY29udGVudCBpbiBhIHJlcG9z\n",
-        "aXRvcnkgcmVxdWVzdGVkIHZpYSB0aGUgQVBJLgoKICAgIFR3byBjb250ZW50\n",
-        "IGluc3RhbmNlcyBjYW4gYmUgY2hlY2tlZCBsaWtlIHNvOjoKCiAgICAgICAg\n",
-        "YzEgPT0gYzIKICAgICAgICBjMSAhPSBjMgoKICAgIEFuZCBpcyBlcXVpdmFs\n",
-        "ZW50IHRvOjoKCiAgICAgICAgYzEuc2hhID09IGMyLnNoYQogICAgICAgIGMx\n",
-        "LnNoYSAhPSBjMi5zaGEKCiAgICBTZWUgYWxzbzogaHR0cDovL2RldmVsb3Bl\n",
-        "ci5naXRodWIuY29tL3YzL3JlcG9zL2NvbnRlbnRzLwogICAgIiIiCiAgICBk\n",
-        "ZWYgX3VwZGF0ZV9hdHRyaWJ1dGVzKHNlbGYsIGNvbnRlbnQpOgogICAgICAg\n",
-        "ICMgbGlua3MKICAgICAgICBzZWxmLl9hcGkgPSBjb250ZW50LmdldCgndXJs\n",
-        "JykKICAgICAgICAjOiBEaWN0aW9uYXJ5IG9mIGxpbmtzCiAgICAgICAgc2Vs\n",
-        "Zi5saW5rcyA9IGNvbnRlbnQuZ2V0KCdfbGlua3MnKQoKICAgICAgICAjOiBV\n",
-        "Ukwgb2YgdGhlIFJFQURNRSBvbiBnaXRodWIuY29tCiAgICAgICAgc2VsZi5o\n",
-        "dG1sX3VybCA9IGNvbnRlbnQuZ2V0KCdodG1sX3VybCcpCgogICAgICAgICM6\n",
-        "IFVSTCBmb3IgdGhlIGdpdCBhcGkgcGVydGFpbmluZyB0byB0aGUgUkVBRE1F\n",
-        "CiAgICAgICAgc2VsZi5naXRfdXJsID0gY29udGVudC5nZXQoJ2dpdF91cmwn\n",
-        "KQoKICAgICAgICAjOiBnaXQ6Ly8gVVJMIG9mIHRoZSBjb250ZW50IGlmIGl0\n",
-        "IGlzIGEgc3VibW9kdWxlCiAgICAgICAgc2VsZi5zdWJtb2R1bGVfZ2l0X3Vy\n",
-        "bCA9IGNvbnRlbnQuZ2V0KCdzdWJtb2R1bGVfZ2l0X3VybCcpCgogICAgICAg\n",
-        "ICMgc2hvdWxkIGFsd2F5cyBiZSAnYmFzZTY0JwogICAgICAgICM6IFJldHVy\n",
-        "bnMgZW5jb2RpbmcgdXNlZCBvbiB0aGUgY29udGVudC4KICAgICAgICBzZWxm\n",
-        "LmVuY29kaW5nID0gY29udGVudC5nZXQoJ2VuY29kaW5nJywgJycpCgogICAg\n",
-        "ICAgICMgY29udGVudCwgYmFzZTY0IGVuY29kZWQgYW5kIGRlY29kZWQKICAg\n",
-        "ICAgICAjOiBCYXNlNjQtZW5jb2RlZCBjb250ZW50IG9mIHRoZSBmaWxlLgog\n",
-        "ICAgICAgIHNlbGYuY29udGVudCA9IGNvbnRlbnQuZ2V0KCdjb250ZW50Jywg\n",
-        "JycpCgogICAgICAgICM6IERlY29kZWQgY29udGVudCBvZiB0aGUgZmlsZSBh\n",
-        "cyBhIGJ5dGVzIG9iamVjdC4gSWYgd2UgdHJ5IHRvIGRlY29kZQogICAgICAg\n",
-        "ICM6IHRvIGNoYXJhY3RlciBzZXQgZm9yIHlvdSwgd2UgbWlnaHQgZW5jb3Vu\n",
-        "dGVyIGFuIGV4Y2VwdGlvbiB3aGljaAogICAgICAgICM6IHdpbGwgcHJldmVu\n",
-        "dCB0aGUgb2JqZWN0IGZyb20gYmVpbmcgY3JlYXRlZC4gT24gcHl0aG9uMiB0\n",
-        "aGlzIGlzIHRoZQogICAgICAgICM6IHNhbWUgYXMgYSBzdHJpbmcsIGJ1dCBv\n",
-        "biBweXRob24zIHlvdSBzaG91bGQgY2FsbCB0aGUgZGVjb2RlIG1ldGhvZAog\n",
-        "ICAgICAgICM6IHdpdGggdGhlIGNoYXJhY3RlciBzZXQgeW91IHdpc2ggdG8g\n",
-        "dXNlLCBlLmcuLAogICAgICAgICM6IGBgY29udGVudC5kZWNvZGVkLmRlY29k\n",
-        "ZSgndXRmLTgnKWBgLgogICAgICAgICM6IC4uIHZlcnNpb25jaGFuZ2VkOjog\n",
-        "MC41LjIKICAgICAgICBzZWxmLmRlY29kZWQgPSAnJwogICAgICAgIGlmIHNl\n",
-        "bGYuZW5jb2RpbmcgPT0gJ2Jhc2U2NCcgYW5kIHNlbGYuY29udGVudDoKICAg\n",
-        "ICAgICAgICAgc2VsZi5kZWNvZGVkID0gYjY0ZGVjb2RlKHNlbGYuY29udGVu\n",
-        "dC5lbmNvZGUoKSkKCiAgICAgICAgIyBmaWxlIG5hbWUsIHBhdGgsIGFuZCBz\n",
-        "aXplCiAgICAgICAgIzogTmFtZSBvZiB0aGUgY29udGVudC4KICAgICAgICBz\n",
-        "ZWxmLm5hbWUgPSBjb250ZW50LmdldCgnbmFtZScsICcnKQogICAgICAgICM6\n",
-        "IFBhdGggdG8gdGhlIGNvbnRlbnQuCiAgICAgICAgc2VsZi5wYXRoID0gY29u\n",
-        "dGVudC5nZXQoJ3BhdGgnLCAnJykKICAgICAgICAjOiBTaXplIG9mIHRoZSBj\n",
-        "b250ZW50CiAgICAgICAgc2VsZi5zaXplID0gY29udGVudC5nZXQoJ3NpemUn\n",
-        "LCAwKQogICAgICAgICM6IFNIQSBzdHJpbmcuCiAgICAgICAgc2VsZi5zaGEg\n",
-        "PSBjb250ZW50LmdldCgnc2hhJywgJycpCiAgICAgICAgIzogVHlwZSBvZiBj\n",
-        "b250ZW50LiAoJ2ZpbGUnLCAnc3ltbGluaycsICdzdWJtb2R1bGUnKQogICAg\n",
-        "ICAgIHNlbGYudHlwZSA9IGNvbnRlbnQuZ2V0KCd0eXBlJywgJycpCiAgICAg\n",
-        "ICAgIzogVGFyZ2V0IHdpbGwgb25seSBiZSBzZXQgb2YgdHlwZSBpcyBhIHN5\n",
-        "bWxpbmsuIFRoaXMgaXMgd2hhdCB0aGUgbGluawogICAgICAgICM6IHBvaW50\n",
-        "cyB0bwogICAgICAgIHNlbGYudGFyZ2V0ID0gY29udGVudC5nZXQoJ3Rhcmdl\n",
-        "dCcsICcnKQoKICAgICAgICBzZWxmLl91bmlxID0gc2VsZi5zaGEKCiAgICBk\n",
-        "ZWYgX3JlcHIoc2VsZik6CiAgICAgICAgcmV0dXJuICc8Q29udGVudCBbezB9\n",
-        "XT4nLmZvcm1hdChzZWxmLnBhdGgpCgogICAgZGVmIF9fZXFfXyhzZWxmLCBv\n",
-        "dGhlcik6CiAgICAgICAgcmV0dXJuIHNlbGYuZGVjb2RlZCA9PSBvdGhlcgoK\n",
-        "ICAgIGRlZiBfX25lX18oc2VsZiwgb3RoZXIpOgogICAgICAgIHJldHVybiBz\n",
-        "ZWxmLnNoYSAhPSBvdGhlcgoKICAgIEByZXF1aXJlc19hdXRoCiAgICBkZWYg\n",
-        "ZGVsZXRlKHNlbGYsIG1lc3NhZ2UsIGNvbW1pdHRlcj1Ob25lLCBhdXRob3I9\n",
-        "Tm9uZSk6CiAgICAgICAgIiIiRGVsZXRlIHRoaXMgZmlsZS4KCiAgICAgICAg\n",
-        "OnBhcmFtIHN0ciBtZXNzYWdlOiAocmVxdWlyZWQpLCBjb21taXQgbWVzc2Fn\n",
-        "ZSB0byBkZXNjcmliZSB0aGUgcmVtb3ZhbAogICAgICAgIDpwYXJhbSBkaWN0\n",
-        "IGNvbW1pdHRlcjogKG9wdGlvbmFsKSwgaWYgbm8gaW5mb3JtYXRpb24gaXMg\n",
-        "Z2l2ZW4gdGhlCiAgICAgICAgICAgIGF1dGhlbnRpY2F0ZWQgdXNlcidzIGlu\n",
-        "Zm9ybWF0aW9uIHdpbGwgYmUgdXNlZC4gWW91IG11c3Qgc3BlY2lmeQogICAg\n",
-        "ICAgICAgICBib3RoIGEgbmFtZSBhbmQgZW1haWwuCiAgICAgICAgOnBhcmFt\n",
-        "IGRpY3QgYXV0aG9yOiAob3B0aW9uYWwpLCBpZiBvbWl0dGVkIHRoaXMgd2ls\n",
-        "bCBiZSBmaWxsZWQgaW4gd2l0aAogICAgICAgICAgICBjb21taXR0ZXIgaW5m\n",
-        "b3JtYXRpb24uIElmIHBhc3NlZCwgeW91IG11c3Qgc3BlY2lmeSBib3RoIGEg\n",
-        "bmFtZSBhbmQKICAgICAgICAgICAgZW1haWwuCiAgICAgICAgOnJldHVybnM6\n",
-        "IGRpY3Rpb25hcnkgb2YgbmV3IGNvbnRlbnQgYW5kIGFzc29jaWF0ZWQgY29t\n",
-        "bWl0CiAgICAgICAgOnJ0eXBlOiA6Y2xhc3M6YH5naXRodWIzLnJlcG9zLmNv\n",
-        "bnRlbnRzLkNvbnRlbnRzYCBhbmQKICAgICAgICAgICAgOmNsYXNzOmB+Z2l0\n",
-        "aHViMy5naXQuQ29tbWl0YAogICAgICAgICIiIgogICAgICAgIGpzb24gPSB7\n",
-        "fQogICAgICAgIGlmIG1lc3NhZ2U6CiAgICAgICAgICAgIGRhdGEgPSB7J21l\n",
-        "c3NhZ2UnOiBtZXNzYWdlLCAnc2hhJzogc2VsZi5zaGEsCiAgICAgICAgICAg\n",
-        "ICAgICAgICAgJ2NvbW1pdHRlcic6IHZhbGlkYXRlX2NvbW1taXR0ZXIoY29t\n",
-        "bWl0dGVyKSwKICAgICAgICAgICAgICAgICAgICAnYXV0aG9yJzogdmFsaWRh\n",
-        "dGVfY29tbW1pdHRlcihhdXRob3IpfQogICAgICAgICAgICBzZWxmLl9yZW1v\n",
-        "dmVfbm9uZShkYXRhKQogICAgICAgICAgICBqc29uID0gc2VsZi5fanNvbihz\n",
-        "ZWxmLl9kZWxldGUoc2VsZi5fYXBpLCBkYXRhPWR1bXBzKGRhdGEpKSwgMjAw\n",
-        "KQogICAgICAgICAgICBpZiAnY29tbWl0JyBpbiBqc29uOgogICAgICAgICAg\n",
-        "ICAgICAganNvblsnY29tbWl0J10gPSBDb21taXQoanNvblsnY29tbWl0J10s\n",
-        "IHNlbGYpCiAgICAgICAgICAgIGlmICdjb250ZW50JyBpbiBqc29uOgogICAg\n",
-        "ICAgICAgICAgICAganNvblsnY29udGVudCddID0gc2VsZi5faW5zdGFuY2Vf\n",
-        "b3JfbnVsbChDb250ZW50cywKICAgICAgICAgICAgICAgICAgICAgICAgICAg\n",
-        "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAganNvblsnY29udGVudCdd\n",
-        "KQogICAgICAgIHJldHVybiBqc29uCgogICAgQHJlcXVpcmVzX2F1dGgKICAg\n",
-        "IGRlZiB1cGRhdGUoc2VsZiwgbWVzc2FnZSwgY29udGVudCwgY29tbWl0dGVy\n",
-        "PU5vbmUsIGF1dGhvcj1Ob25lKToKICAgICAgICAiIiJVcGRhdGUgdGhpcyBm\n",
-        "aWxlLgoKICAgICAgICA6cGFyYW0gc3RyIG1lc3NhZ2U6IChyZXF1aXJlZCks\n",
-        "IGNvbW1pdCBtZXNzYWdlIHRvIGRlc2NyaWJlIHRoZSB1cGRhdGUKICAgICAg\n",
-        "ICA6cGFyYW0gc3RyIGNvbnRlbnQ6IChyZXF1aXJlZCksIGNvbnRlbnQgdG8g\n",
-        "dXBkYXRlIHRoZSBmaWxlIHdpdGgKICAgICAgICA6cGFyYW0gZGljdCBjb21t\n",
-        "aXR0ZXI6IChvcHRpb25hbCksIGlmIG5vIGluZm9ybWF0aW9uIGlzIGdpdmVu\n",
-        "IHRoZQogICAgICAgICAgICBhdXRoZW50aWNhdGVkIHVzZXIncyBpbmZvcm1h\n",
-        "dGlvbiB3aWxsIGJlIHVzZWQuIFlvdSBtdXN0IHNwZWNpZnkKICAgICAgICAg\n",
-        "ICAgYm90aCBhIG5hbWUgYW5kIGVtYWlsLgogICAgICAgIDpwYXJhbSBkaWN0\n",
-        "IGF1dGhvcjogKG9wdGlvbmFsKSwgaWYgb21pdHRlZCB0aGlzIHdpbGwgYmUg\n",
-        "ZmlsbGVkIGluIHdpdGgKICAgICAgICAgICAgY29tbWl0dGVyIGluZm9ybWF0\n",
-        "aW9uLiBJZiBwYXNzZWQsIHlvdSBtdXN0IHNwZWNpZnkgYm90aCBhIG5hbWUg\n",
-        "YW5kCiAgICAgICAgICAgIGVtYWlsLgogICAgICAgIDpyZXR1cm5zOiBkaWN0\n",
-        "aW9uYXJ5IGNvbnRhaW5pbmcgdGhlIHVwZGF0ZWQgY29udGVudHMgb2JqZWN0\n",
-        "IGFuZCB0aGUKICAgICAgICAgICAgY29tbWl0IGluIHdoaWNoIGl0IHdhcyBj\n",
-        "aGFuZ2VkLgogICAgICAgIDpydHlwZTogZGljdGlvbmFyeSBvZiA6Y2xhc3M6\n",
-        "YH5naXRodWIzLnJlcG9zLmNvbnRlbnRzLkNvbnRlbnRzYCBhbmQKICAgICAg\n",
-        "ICAgICAgOmNsYXNzOmB+Z2l0aHViMy5naXQuQ29tbWl0YAogICAgICAgICIi\n",
-        "IgogICAgICAgIGlmIGNvbnRlbnQgYW5kIG5vdCBpc2luc3RhbmNlKGNvbnRl\n",
-        "bnQsIGJ5dGVzKToKICAgICAgICAgICAgcmFpc2UgVmFsdWVFcnJvciggICMg\n",
-        "KE5vIGNvdmVyYWdlKQogICAgICAgICAgICAgICAgJ2NvbnRlbnQgbXVzdCBi\n",
-        "ZSBhIGJ5dGVzIG9iamVjdCcpICAjIChObyBjb3ZlcmFnZSkKCiAgICAgICAg\n",
-        "anNvbiA9IE5vbmUKICAgICAgICBpZiBtZXNzYWdlIGFuZCBjb250ZW50Ogog\n",
-        "ICAgICAgICAgICBjb250ZW50ID0gYjY0ZW5jb2RlKGNvbnRlbnQpLmRlY29k\n",
-        "ZSgndXRmLTgnKQogICAgICAgICAgICBkYXRhID0geydtZXNzYWdlJzogbWVz\n",
-        "c2FnZSwgJ2NvbnRlbnQnOiBjb250ZW50LCAnc2hhJzogc2VsZi5zaGEsCiAg\n",
-        "ICAgICAgICAgICAgICAgICAgJ2NvbW1pdHRlcic6IHZhbGlkYXRlX2NvbW1t\n",
-        "aXR0ZXIoY29tbWl0dGVyKSwKICAgICAgICAgICAgICAgICAgICAnYXV0aG9y\n",
-        "JzogdmFsaWRhdGVfY29tbW1pdHRlcihhdXRob3IpfQogICAgICAgICAgICBz\n",
-        "ZWxmLl9yZW1vdmVfbm9uZShkYXRhKQogICAgICAgICAgICBqc29uID0gc2Vs\n",
-        "Zi5fanNvbihzZWxmLl9wdXQoc2VsZi5fYXBpLCBkYXRhPWR1bXBzKGRhdGEp\n",
-        "KSwgMjAwKQogICAgICAgICAgICBpZiAnY29udGVudCcgaW4ganNvbjoKICAg\n",
-        "ICAgICAgICAgICAgIHNlbGYuX3VwZGF0ZV9hdHRyaWJ1dGVzKGpzb25bJ2Nv\n",
-        "bnRlbnQnXSkKICAgICAgICAgICAgICAgIGpzb25bJ2NvbnRlbnQnXSA9IHNl\n",
-        "bGYKICAgICAgICAgICAgaWYgJ2NvbW1pdCcgaW4ganNvbjoKICAgICAgICAg\n",
-        "ICAgICAgIGpzb25bJ2NvbW1pdCddID0gQ29tbWl0KGpzb25bJ2NvbW1pdCdd\n",
-        "LCBzZWxmKQogICAgICAgIHJldHVybiBqc29uCgoKZGVmIHZhbGlkYXRlX2Nv\n",
-        "bW1taXR0ZXIoZCk6CiAgICBpZiBkIGFuZCBkLmdldCgnbmFtZScpIGFuZCBk\n",
-        "LmdldCgnZW1haWwnKToKICAgICAgICByZXR1cm4gZAogICAgcmV0dXJuIE5v\n",
-        "bmUK\n",
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "But that's base64 encoded text. So github3.py provides the content decoded as well:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(contents.decoded)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "# -*- coding: utf-8 -*-\n",
-        "\"\"\"\n",
-        "github3.repos.contents\n",
-        "======================\n",
-        "\n",
-        "This module contains the Contents object pertaining to READMEs and other files\n",
-        "that can be accessed via the GitHub API.\n",
-        "\n",
-        "\"\"\"\n",
-        "from __future__ import unicode_literals\n",
-        "\n",
-        "from json import dumps\n",
-        "from base64 import b64decode, b64encode\n",
-        "from ..git import Commit\n",
-        "from ..models import GitHubCore\n",
-        "from ..decorators import requires_auth\n",
-        "\n",
-        "\n",
-        "class Contents(GitHubCore):\n",
-        "    \"\"\"The :class:`Contents <Contents>` object. It holds the information\n",
-        "    concerning any content in a repository requested via the API.\n",
-        "\n",
-        "    Two content instances can be checked like so::\n",
-        "\n",
-        "        c1 == c2\n",
-        "        c1 != c2\n",
-        "\n",
-        "    And is equivalent to::\n",
-        "\n",
-        "        c1.sha == c2.sha\n",
-        "        c1.sha != c2.sha\n",
-        "\n",
-        "    See also: http://developer.github.com/v3/repos/contents/\n",
-        "    \"\"\"\n",
-        "    def _update_attributes(self, content):\n",
-        "        # links\n",
-        "        self._api = content.get('url')\n",
-        "        #: Dictionary of links\n",
-        "        self.links = content.get('_links')\n",
-        "\n",
-        "        #: URL of the README on github.com\n",
-        "        self.html_url = content.get('html_url')\n",
-        "\n",
-        "        #: URL for the git api pertaining to the README\n",
-        "        self.git_url = content.get('git_url')\n",
-        "\n",
-        "        #: git:// URL of the content if it is a submodule\n",
-        "        self.submodule_git_url = content.get('submodule_git_url')\n",
-        "\n",
-        "        # should always be 'base64'\n",
-        "        #: Returns encoding used on the content.\n",
-        "        self.encoding = content.get('encoding', '')\n",
-        "\n",
-        "        # content, base64 encoded and decoded\n",
-        "        #: Base64-encoded content of the file.\n",
-        "        self.content = content.get('content', '')\n",
-        "\n",
-        "        #: Decoded content of the file as a bytes object. If we try to decode\n",
-        "        #: to character set for you, we might encounter an exception which\n",
-        "        #: will prevent the object from being created. On python2 this is the\n",
-        "        #: same as a string, but on python3 you should call the decode method\n",
-        "        #: with the character set you wish to use, e.g.,\n",
-        "        #: ``content.decoded.decode('utf-8')``.\n",
-        "        #: .. versionchanged:: 0.5.2\n",
-        "        self.decoded = ''\n",
-        "        if self.encoding == 'base64' and self.content:\n",
-        "            self.decoded = b64decode(self.content.encode())\n",
-        "\n",
-        "        # file name, path, and size\n",
-        "        #: Name of the content.\n",
-        "        self.name = content.get('name', '')\n",
-        "        #: Path to the content.\n",
-        "        self.path = content.get('path', '')\n",
-        "        #: Size of the content\n",
-        "        self.size = content.get('size', 0)\n",
-        "        #: SHA string.\n",
-        "        self.sha = content.get('sha', '')\n",
-        "        #: Type of content. ('file', 'symlink', 'submodule')\n",
-        "        self.type = content.get('type', '')\n",
-        "        #: Target will only be set of type is a symlink. This is what the link\n",
-        "        #: points to\n",
-        "        self.target = content.get('target', '')\n",
-        "\n",
-        "        self._uniq = self.sha\n",
-        "\n",
-        "    def _repr(self):\n",
-        "        return '<Content [{0}]>'.format(self.path)\n",
-        "\n",
-        "    def __eq__(self, other):\n",
-        "        return self.decoded == other\n",
-        "\n",
-        "    def __ne__(self, other):\n",
-        "        return self.sha != other\n",
-        "\n",
-        "    @requires_auth\n",
-        "    def delete(self, message, committer=None, author=None):\n",
-        "        \"\"\"Delete this file.\n",
-        "\n",
-        "        :param str message: (required), commit message to describe the removal\n",
-        "        :param dict committer: (optional), if no information is given the\n",
-        "            authenticated user's information will be used. You must specify\n",
-        "            both a name and email.\n",
-        "        :param dict author: (optional), if omitted this will be filled in with\n",
-        "            committer information. If passed, you must specify both a name and\n",
-        "            email.\n",
-        "        :returns: dictionary of new content and associated commit\n",
-        "        :rtype: :class:`~github3.repos.contents.Contents` and\n",
-        "            :class:`~github3.git.Commit`\n",
-        "        \"\"\"\n",
-        "        json = {}\n",
-        "        if message:\n",
-        "            data = {'message': message, 'sha': self.sha,\n",
-        "                    'committer': validate_commmitter(committer),\n",
-        "                    'author': validate_commmitter(author)}\n",
-        "            self._remove_none(data)\n",
-        "            json = self._json(self._delete(self._api, data=dumps(data)), 200)\n",
-        "            if 'commit' in json:\n",
-        "                json['commit'] = Commit(json['commit'], self)\n",
-        "            if 'content' in json:\n",
-        "                json['content'] = self._instance_or_null(Contents,\n",
-        "                                                         json['content'])\n",
-        "        return json\n",
-        "\n",
-        "    @requires_auth\n",
-        "    def update(self, message, content, committer=None, author=None):\n",
-        "        \"\"\"Update this file.\n",
-        "\n",
-        "        :param str message: (required), commit message to describe the update\n",
-        "        :param str content: (required), content to update the file with\n",
-        "        :param dict committer: (optional), if no information is given the\n",
-        "            authenticated user's information will be used. You must specify\n",
-        "            both a name and email.\n",
-        "        :param dict author: (optional), if omitted this will be filled in with\n",
-        "            committer information. If passed, you must specify both a name and\n",
-        "            email.\n",
-        "        :returns: dictionary containing the updated contents object and the\n",
-        "            commit in which it was changed.\n",
-        "        :rtype: dictionary of :class:`~github3.repos.contents.Contents` and\n",
-        "            :class:`~github3.git.Commit`\n",
-        "        \"\"\"\n",
-        "        if content and not isinstance(content, bytes):\n",
-        "            raise ValueError(  # (No coverage)\n",
-        "                'content must be a bytes object')  # (No coverage)\n",
-        "\n",
-        "        json = None\n",
-        "        if message and content:\n",
-        "            content = b64encode(content).decode('utf-8')\n",
-        "            data = {'message': message, 'content': content, 'sha': self.sha,\n",
-        "                    'committer': validate_commmitter(committer),\n",
-        "                    'author': validate_commmitter(author)}\n",
-        "            self._remove_none(data)\n",
-        "            json = self._json(self._put(self._api, data=dumps(data)), 200)\n",
-        "            if 'content' in json:\n",
-        "                self._update_attributes(json['content'])\n",
-        "                json['content'] = self\n",
-        "            if 'commit' in json:\n",
-        "                json['commit'] = Commit(json['commit'], self)\n",
-        "        return json\n",
-        "\n",
-        "\n",
-        "def validate_commmitter(d):\n",
-        "    if d and d.get('name') and d.get('email'):\n",
-        "        return d\n",
-        "    return None\n",
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "github3.py tries to preserve original names of data it receives so that users can access that easily and without having to guess. From here, (if we were logged in) we could easily update or even delete this file altogether."
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Retrieving a directory's contents"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import github3"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "repo = github3.repository('sigmavirus24', 'github3.py')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dir_contents = repo.directory_contents('github3/search/')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dir_contents"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 11,
-       "text": [
-        "[(u'__init__.py', <Content [github3/search/__init__.py]>),\n",
-        " (u'code.py', <Content [github3/search/code.py]>),\n",
-        " (u'issue.py', <Content [github3/search/issue.py]>),\n",
-        " (u'repository.py', <Content [github3/search/repository.py]>),\n",
-        " (u'user.py', <Content [github3/search/user.py]>)]"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dc = dict(dir_contents)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dc['user.py'].decoded"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 13,
-       "text": [
-        "u''"
-       ]
-      }
-     ],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In many instances when GitHub returns more than one instance of a resource, they don't return the entirety of each resource. Here's we have an example of this. The file bodies would be expensive to return for a directory with a lot of files, so GitHub omits them. We can still retrieve it. We just need to make another call to the API for the information."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dc['user.py'].refresh()\n",
-      "print(dc['user.py'].decoded)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "# -*- coding: utf-8 -*-\n",
-        "from __future__ import unicode_literals\n",
-        "\n",
-        "from ..models import GitHubCore\n",
-        "from ..users import User\n",
-        "\n",
-        "\n",
-        "class UserSearchResult(GitHubCore):\n",
-        "    def _update_attributes(self, data):\n",
-        "        result = data.copy()\n",
-        "        #: Score of this search result\n",
-        "        self.score = result.pop('score')\n",
-        "        #: Text matches\n",
-        "        self.text_matches = result.pop('text_matches', [])\n",
-        "        #: User object matching the search\n",
-        "        self.user = User(result, self)\n",
-        "\n",
-        "    def _repr(self):\n",
-        "        return '<UserSearchResult [{0}]>'.format(self.user)\n",
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 15
     }
    ],
-   "metadata": {}
+   "source": [
+    "print(contents.name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6a563ab33cabc0c47faf20f2a349e9dd6ce28d00\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(contents.sha)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also get the contents of the file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IyAtKi0gY29kaW5nOiB1dGYtOCAtKi0KIiIiCmdpdGh1YjMucmVwb3MuY29u\n",
+      "dGVudHMKPT09PT09PT09PT09PT09PT09PT09PQoKVGhpcyBtb2R1bGUgY29u\n",
+      "dGFpbnMgdGhlIENvbnRlbnRzIG9iamVjdCBwZXJ0YWluaW5nIHRvIFJFQURN\n",
+      "RXMgYW5kIG90aGVyIGZpbGVzCnRoYXQgY2FuIGJlIGFjY2Vzc2VkIHZpYSB0\n",
+      "aGUgR2l0SHViIEFQSS4KCiIiIgpmcm9tIF9fZnV0dXJlX18gaW1wb3J0IHVu\n",
+      "aWNvZGVfbGl0ZXJhbHMKCmZyb20ganNvbiBpbXBvcnQgZHVtcHMKZnJvbSBi\n",
+      "YXNlNjQgaW1wb3J0IGI2NGRlY29kZSwgYjY0ZW5jb2RlCmZyb20gLi5naXQg\n",
+      "aW1wb3J0IENvbW1pdApmcm9tIC4ubW9kZWxzIGltcG9ydCBHaXRIdWJDb3Jl\n",
+      "CmZyb20gLi5kZWNvcmF0b3JzIGltcG9ydCByZXF1aXJlc19hdXRoCgoKY2xh\n",
+      "c3MgQ29udGVudHMoR2l0SHViQ29yZSk6CiAgICAiIiJUaGUgOmNsYXNzOmBD\n",
+      "b250ZW50cyA8Q29udGVudHM+YCBvYmplY3QuIEl0IGhvbGRzIHRoZSBpbmZv\n",
+      "cm1hdGlvbgogICAgY29uY2VybmluZyBhbnkgY29udGVudCBpbiBhIHJlcG9z\n",
+      "aXRvcnkgcmVxdWVzdGVkIHZpYSB0aGUgQVBJLgoKICAgIFR3byBjb250ZW50\n",
+      "IGluc3RhbmNlcyBjYW4gYmUgY2hlY2tlZCBsaWtlIHNvOjoKCiAgICAgICAg\n",
+      "YzEgPT0gYzIKICAgICAgICBjMSAhPSBjMgoKICAgIEFuZCBpcyBlcXVpdmFs\n",
+      "ZW50IHRvOjoKCiAgICAgICAgYzEuc2hhID09IGMyLnNoYQogICAgICAgIGMx\n",
+      "LnNoYSAhPSBjMi5zaGEKCiAgICBTZWUgYWxzbzogaHR0cDovL2RldmVsb3Bl\n",
+      "ci5naXRodWIuY29tL3YzL3JlcG9zL2NvbnRlbnRzLwogICAgIiIiCiAgICBk\n",
+      "ZWYgX3VwZGF0ZV9hdHRyaWJ1dGVzKHNlbGYsIGNvbnRlbnQpOgogICAgICAg\n",
+      "ICMgbGlua3MKICAgICAgICBzZWxmLl9hcGkgPSBjb250ZW50LmdldCgndXJs\n",
+      "JykKICAgICAgICAjOiBEaWN0aW9uYXJ5IG9mIGxpbmtzCiAgICAgICAgc2Vs\n",
+      "Zi5saW5rcyA9IGNvbnRlbnQuZ2V0KCdfbGlua3MnKQoKICAgICAgICAjOiBV\n",
+      "Ukwgb2YgdGhlIFJFQURNRSBvbiBnaXRodWIuY29tCiAgICAgICAgc2VsZi5o\n",
+      "dG1sX3VybCA9IGNvbnRlbnQuZ2V0KCdodG1sX3VybCcpCgogICAgICAgICM6\n",
+      "IFVSTCBmb3IgdGhlIGdpdCBhcGkgcGVydGFpbmluZyB0byB0aGUgUkVBRE1F\n",
+      "CiAgICAgICAgc2VsZi5naXRfdXJsID0gY29udGVudC5nZXQoJ2dpdF91cmwn\n",
+      "KQoKICAgICAgICAjOiBnaXQ6Ly8gVVJMIG9mIHRoZSBjb250ZW50IGlmIGl0\n",
+      "IGlzIGEgc3VibW9kdWxlCiAgICAgICAgc2VsZi5zdWJtb2R1bGVfZ2l0X3Vy\n",
+      "bCA9IGNvbnRlbnQuZ2V0KCdzdWJtb2R1bGVfZ2l0X3VybCcpCgogICAgICAg\n",
+      "ICMgc2hvdWxkIGFsd2F5cyBiZSAnYmFzZTY0JwogICAgICAgICM6IFJldHVy\n",
+      "bnMgZW5jb2RpbmcgdXNlZCBvbiB0aGUgY29udGVudC4KICAgICAgICBzZWxm\n",
+      "LmVuY29kaW5nID0gY29udGVudC5nZXQoJ2VuY29kaW5nJywgJycpCgogICAg\n",
+      "ICAgICMgY29udGVudCwgYmFzZTY0IGVuY29kZWQgYW5kIGRlY29kZWQKICAg\n",
+      "ICAgICAjOiBCYXNlNjQtZW5jb2RlZCBjb250ZW50IG9mIHRoZSBmaWxlLgog\n",
+      "ICAgICAgIHNlbGYuY29udGVudCA9IGNvbnRlbnQuZ2V0KCdjb250ZW50Jywg\n",
+      "JycpCgogICAgICAgICM6IERlY29kZWQgY29udGVudCBvZiB0aGUgZmlsZSBh\n",
+      "cyBhIGJ5dGVzIG9iamVjdC4gSWYgd2UgdHJ5IHRvIGRlY29kZQogICAgICAg\n",
+      "ICM6IHRvIGNoYXJhY3RlciBzZXQgZm9yIHlvdSwgd2UgbWlnaHQgZW5jb3Vu\n",
+      "dGVyIGFuIGV4Y2VwdGlvbiB3aGljaAogICAgICAgICM6IHdpbGwgcHJldmVu\n",
+      "dCB0aGUgb2JqZWN0IGZyb20gYmVpbmcgY3JlYXRlZC4gT24gcHl0aG9uMiB0\n",
+      "aGlzIGlzIHRoZQogICAgICAgICM6IHNhbWUgYXMgYSBzdHJpbmcsIGJ1dCBv\n",
+      "biBweXRob24zIHlvdSBzaG91bGQgY2FsbCB0aGUgZGVjb2RlIG1ldGhvZAog\n",
+      "ICAgICAgICM6IHdpdGggdGhlIGNoYXJhY3RlciBzZXQgeW91IHdpc2ggdG8g\n",
+      "dXNlLCBlLmcuLAogICAgICAgICM6IGBgY29udGVudC5kZWNvZGVkLmRlY29k\n",
+      "ZSgndXRmLTgnKWBgLgogICAgICAgICM6IC4uIHZlcnNpb25jaGFuZ2VkOjog\n",
+      "MC41LjIKICAgICAgICBzZWxmLmRlY29kZWQgPSAnJwogICAgICAgIGlmIHNl\n",
+      "bGYuZW5jb2RpbmcgPT0gJ2Jhc2U2NCcgYW5kIHNlbGYuY29udGVudDoKICAg\n",
+      "ICAgICAgICAgc2VsZi5kZWNvZGVkID0gYjY0ZGVjb2RlKHNlbGYuY29udGVu\n",
+      "dC5lbmNvZGUoKSkKCiAgICAgICAgIyBmaWxlIG5hbWUsIHBhdGgsIGFuZCBz\n",
+      "aXplCiAgICAgICAgIzogTmFtZSBvZiB0aGUgY29udGVudC4KICAgICAgICBz\n",
+      "ZWxmLm5hbWUgPSBjb250ZW50LmdldCgnbmFtZScsICcnKQogICAgICAgICM6\n",
+      "IFBhdGggdG8gdGhlIGNvbnRlbnQuCiAgICAgICAgc2VsZi5wYXRoID0gY29u\n",
+      "dGVudC5nZXQoJ3BhdGgnLCAnJykKICAgICAgICAjOiBTaXplIG9mIHRoZSBj\n",
+      "b250ZW50CiAgICAgICAgc2VsZi5zaXplID0gY29udGVudC5nZXQoJ3NpemUn\n",
+      "LCAwKQogICAgICAgICM6IFNIQSBzdHJpbmcuCiAgICAgICAgc2VsZi5zaGEg\n",
+      "PSBjb250ZW50LmdldCgnc2hhJywgJycpCiAgICAgICAgIzogVHlwZSBvZiBj\n",
+      "b250ZW50LiAoJ2ZpbGUnLCAnc3ltbGluaycsICdzdWJtb2R1bGUnKQogICAg\n",
+      "ICAgIHNlbGYudHlwZSA9IGNvbnRlbnQuZ2V0KCd0eXBlJywgJycpCiAgICAg\n",
+      "ICAgIzogVGFyZ2V0IHdpbGwgb25seSBiZSBzZXQgb2YgdHlwZSBpcyBhIHN5\n",
+      "bWxpbmsuIFRoaXMgaXMgd2hhdCB0aGUgbGluawogICAgICAgICM6IHBvaW50\n",
+      "cyB0bwogICAgICAgIHNlbGYudGFyZ2V0ID0gY29udGVudC5nZXQoJ3Rhcmdl\n",
+      "dCcsICcnKQoKICAgICAgICBzZWxmLl91bmlxID0gc2VsZi5zaGEKCiAgICBk\n",
+      "ZWYgX3JlcHIoc2VsZik6CiAgICAgICAgcmV0dXJuICc8Q29udGVudCBbezB9\n",
+      "XT4nLmZvcm1hdChzZWxmLnBhdGgpCgogICAgZGVmIF9fZXFfXyhzZWxmLCBv\n",
+      "dGhlcik6CiAgICAgICAgcmV0dXJuIHNlbGYuZGVjb2RlZCA9PSBvdGhlcgoK\n",
+      "ICAgIGRlZiBfX25lX18oc2VsZiwgb3RoZXIpOgogICAgICAgIHJldHVybiBz\n",
+      "ZWxmLnNoYSAhPSBvdGhlcgoKICAgIEByZXF1aXJlc19hdXRoCiAgICBkZWYg\n",
+      "ZGVsZXRlKHNlbGYsIG1lc3NhZ2UsIGJyYW5jaD1Ob25lLCBjb21taXR0ZXI9\n",
+      "Tm9uZSwgYXV0aG9yPU5vbmUpOgogICAgICAgICIiIkRlbGV0ZSB0aGlzIGZp\n",
+      "bGUuCgogICAgICAgIDpwYXJhbSBzdHIgbWVzc2FnZTogKHJlcXVpcmVkKSwg\n",
+      "Y29tbWl0IG1lc3NhZ2UgdG8gZGVzY3JpYmUgdGhlIHJlbW92YWwKICAgICAg\n",
+      "ICA6cGFyYW0gc3RyIGJyYW5jaDogKG9wdGlvbmFsKSwgYnJhbmNoIHdoZXJl\n",
+      "IHRoZSBmaWxlIGV4aXN0cy4KICAgICAgICAgICAgRGVmYXVsdHMgdG8gdGhl\n",
+      "IGRlZmF1bHQgYnJhbmNoIG9mIHRoZSByZXBvc2l0b3J5LgogICAgICAgIDpw\n",
+      "YXJhbSBkaWN0IGNvbW1pdHRlcjogKG9wdGlvbmFsKSwgaWYgbm8gaW5mb3Jt\n",
+      "YXRpb24gaXMgZ2l2ZW4gdGhlCiAgICAgICAgICAgIGF1dGhlbnRpY2F0ZWQg\n",
+      "dXNlcidzIGluZm9ybWF0aW9uIHdpbGwgYmUgdXNlZC4gWW91IG11c3Qgc3Bl\n",
+      "Y2lmeQogICAgICAgICAgICBib3RoIGEgbmFtZSBhbmQgZW1haWwuCiAgICAg\n",
+      "ICAgOnBhcmFtIGRpY3QgYXV0aG9yOiAob3B0aW9uYWwpLCBpZiBvbWl0dGVk\n",
+      "IHRoaXMgd2lsbCBiZSBmaWxsZWQgaW4gd2l0aAogICAgICAgICAgICBjb21t\n",
+      "aXR0ZXIgaW5mb3JtYXRpb24uIElmIHBhc3NlZCwgeW91IG11c3Qgc3BlY2lm\n",
+      "eSBib3RoIGEgbmFtZSBhbmQKICAgICAgICAgICAgZW1haWwuCiAgICAgICAg\n",
+      "OnJldHVybnM6IGRpY3Rpb25hcnkgb2YgbmV3IGNvbnRlbnQgYW5kIGFzc29j\n",
+      "aWF0ZWQgY29tbWl0CiAgICAgICAgOnJ0eXBlOiA6Y2xhc3M6YH5naXRodWIz\n",
+      "LnJlcG9zLmNvbnRlbnRzLkNvbnRlbnRzYCBhbmQKICAgICAgICAgICAgOmNs\n",
+      "YXNzOmB+Z2l0aHViMy5naXQuQ29tbWl0YAogICAgICAgICIiIgogICAgICAg\n",
+      "IGpzb24gPSB7fQogICAgICAgIGlmIG1lc3NhZ2U6CiAgICAgICAgICAgIGRh\n",
+      "dGEgPSB7J21lc3NhZ2UnOiBtZXNzYWdlLCAnc2hhJzogc2VsZi5zaGEsICdi\n",
+      "cmFuY2gnOiBicmFuY2gsCiAgICAgICAgICAgICAgICAgICAgJ2NvbW1pdHRl\n",
+      "cic6IHZhbGlkYXRlX2NvbW1taXR0ZXIoY29tbWl0dGVyKSwKICAgICAgICAg\n",
+      "ICAgICAgICAgICAnYXV0aG9yJzogdmFsaWRhdGVfY29tbW1pdHRlcihhdXRo\n",
+      "b3IpfQogICAgICAgICAgICBzZWxmLl9yZW1vdmVfbm9uZShkYXRhKQogICAg\n",
+      "ICAgICAgICBqc29uID0gc2VsZi5fanNvbihzZWxmLl9kZWxldGUoc2VsZi5f\n",
+      "YXBpLCBkYXRhPWR1bXBzKGRhdGEpKSwgMjAwKQogICAgICAgICAgICBpZiAn\n",
+      "Y29tbWl0JyBpbiBqc29uOgogICAgICAgICAgICAgICAganNvblsnY29tbWl0\n",
+      "J10gPSBDb21taXQoanNvblsnY29tbWl0J10sIHNlbGYpCiAgICAgICAgICAg\n",
+      "IGlmICdjb250ZW50JyBpbiBqc29uOgogICAgICAgICAgICAgICAganNvblsn\n",
+      "Y29udGVudCddID0gc2VsZi5faW5zdGFuY2Vfb3JfbnVsbChDb250ZW50cywK\n",
+      "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg\n",
+      "ICAgICAgICAgICAganNvblsnY29udGVudCddKQogICAgICAgIHJldHVybiBq\n",
+      "c29uCgogICAgQHJlcXVpcmVzX2F1dGgKICAgIGRlZiB1cGRhdGUoc2VsZiwg\n",
+      "bWVzc2FnZSwgY29udGVudCwgYnJhbmNoPU5vbmUsIGNvbW1pdHRlcj1Ob25l\n",
+      "LAogICAgICAgICAgICAgICBhdXRob3I9Tm9uZSk6CiAgICAgICAgIiIiVXBk\n",
+      "YXRlIHRoaXMgZmlsZS4KCiAgICAgICAgOnBhcmFtIHN0ciBtZXNzYWdlOiAo\n",
+      "cmVxdWlyZWQpLCBjb21taXQgbWVzc2FnZSB0byBkZXNjcmliZSB0aGUgdXBk\n",
+      "YXRlCiAgICAgICAgOnBhcmFtIHN0ciBjb250ZW50OiAocmVxdWlyZWQpLCBj\n",
+      "b250ZW50IHRvIHVwZGF0ZSB0aGUgZmlsZSB3aXRoCiAgICAgICAgOnBhcmFt\n",
+      "IHN0ciBicmFuY2g6IChvcHRpb25hbCksIGJyYW5jaCB3aGVyZSB0aGUgZmls\n",
+      "ZSBleGlzdHMuCiAgICAgICAgICAgIERlZmF1bHRzIHRvIHRoZSBkZWZhdWx0\n",
+      "IGJyYW5jaCBvZiB0aGUgcmVwb3NpdG9yeS4KICAgICAgICA6cGFyYW0gZGlj\n",
+      "dCBjb21taXR0ZXI6IChvcHRpb25hbCksIGlmIG5vIGluZm9ybWF0aW9uIGlz\n",
+      "IGdpdmVuIHRoZQogICAgICAgICAgICBhdXRoZW50aWNhdGVkIHVzZXIncyBp\n",
+      "bmZvcm1hdGlvbiB3aWxsIGJlIHVzZWQuIFlvdSBtdXN0IHNwZWNpZnkKICAg\n",
+      "ICAgICAgICAgYm90aCBhIG5hbWUgYW5kIGVtYWlsLgogICAgICAgIDpwYXJh\n",
+      "bSBkaWN0IGF1dGhvcjogKG9wdGlvbmFsKSwgaWYgb21pdHRlZCB0aGlzIHdp\n",
+      "bGwgYmUgZmlsbGVkIGluIHdpdGgKICAgICAgICAgICAgY29tbWl0dGVyIGlu\n",
+      "Zm9ybWF0aW9uLiBJZiBwYXNzZWQsIHlvdSBtdXN0IHNwZWNpZnkgYm90aCBh\n",
+      "IG5hbWUgYW5kCiAgICAgICAgICAgIGVtYWlsLgogICAgICAgIDpyZXR1cm5z\n",
+      "OiBkaWN0aW9uYXJ5IGNvbnRhaW5pbmcgdGhlIHVwZGF0ZWQgY29udGVudHMg\n",
+      "b2JqZWN0IGFuZCB0aGUKICAgICAgICAgICAgY29tbWl0IGluIHdoaWNoIGl0\n",
+      "IHdhcyBjaGFuZ2VkLgogICAgICAgIDpydHlwZTogZGljdGlvbmFyeSBvZiA6\n",
+      "Y2xhc3M6YH5naXRodWIzLnJlcG9zLmNvbnRlbnRzLkNvbnRlbnRzYCBhbmQK\n",
+      "ICAgICAgICAgICAgOmNsYXNzOmB+Z2l0aHViMy5naXQuQ29tbWl0YAogICAg\n",
+      "ICAgICIiIgogICAgICAgIGlmIGNvbnRlbnQgYW5kIG5vdCBpc2luc3RhbmNl\n",
+      "KGNvbnRlbnQsIGJ5dGVzKToKICAgICAgICAgICAgcmFpc2UgVmFsdWVFcnJv\n",
+      "ciggICMgKE5vIGNvdmVyYWdlKQogICAgICAgICAgICAgICAgJ2NvbnRlbnQg\n",
+      "bXVzdCBiZSBhIGJ5dGVzIG9iamVjdCcpICAjIChObyBjb3ZlcmFnZSkKCiAg\n",
+      "ICAgICAganNvbiA9IE5vbmUKICAgICAgICBpZiBtZXNzYWdlIGFuZCBjb250\n",
+      "ZW50OgogICAgICAgICAgICBjb250ZW50ID0gYjY0ZW5jb2RlKGNvbnRlbnQp\n",
+      "LmRlY29kZSgndXRmLTgnKQogICAgICAgICAgICBkYXRhID0geydtZXNzYWdl\n",
+      "JzogbWVzc2FnZSwgJ2NvbnRlbnQnOiBjb250ZW50LCAnYnJhbmNoJzogYnJh\n",
+      "bmNoLAogICAgICAgICAgICAgICAgICAgICdzaGEnOiBzZWxmLnNoYSwKICAg\n",
+      "ICAgICAgICAgICAgICAgICAnY29tbWl0dGVyJzogdmFsaWRhdGVfY29tbW1p\n",
+      "dHRlcihjb21taXR0ZXIpLAogICAgICAgICAgICAgICAgICAgICdhdXRob3In\n",
+      "OiB2YWxpZGF0ZV9jb21tbWl0dGVyKGF1dGhvcil9CiAgICAgICAgICAgIHNl\n",
+      "bGYuX3JlbW92ZV9ub25lKGRhdGEpCiAgICAgICAgICAgIGpzb24gPSBzZWxm\n",
+      "Ll9qc29uKHNlbGYuX3B1dChzZWxmLl9hcGksIGRhdGE9ZHVtcHMoZGF0YSkp\n",
+      "LCAyMDApCiAgICAgICAgICAgIGlmICdjb250ZW50JyBpbiBqc29uOgogICAg\n",
+      "ICAgICAgICAgICAgc2VsZi5fdXBkYXRlX2F0dHJpYnV0ZXMoanNvblsnY29u\n",
+      "dGVudCddKQogICAgICAgICAgICAgICAganNvblsnY29udGVudCddID0gc2Vs\n",
+      "ZgogICAgICAgICAgICBpZiAnY29tbWl0JyBpbiBqc29uOgogICAgICAgICAg\n",
+      "ICAgICAganNvblsnY29tbWl0J10gPSBDb21taXQoanNvblsnY29tbWl0J10s\n",
+      "IHNlbGYpCiAgICAgICAgcmV0dXJuIGpzb24KCgpkZWYgdmFsaWRhdGVfY29t\n",
+      "bW1pdHRlcihkKToKICAgIGlmIGQgYW5kIGQuZ2V0KCduYW1lJykgYW5kIGQu\n",
+      "Z2V0KCdlbWFpbCcpOgogICAgICAgIHJldHVybiBkCiAgICByZXR1cm4gTm9u\n",
+      "ZQo=\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(contents.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But that's base64 encoded text. So github3.py provides the content decoded as well:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# -*- coding: utf-8 -*-\n",
+      "\"\"\"\n",
+      "github3.repos.contents\n",
+      "======================\n",
+      "\n",
+      "This module contains the Contents object pertaining to READMEs and other files\n",
+      "that can be accessed via the GitHub API.\n",
+      "\n",
+      "\"\"\"\n",
+      "from __future__ import unicode_literals\n",
+      "\n",
+      "from json import dumps\n",
+      "from base64 import b64decode, b64encode\n",
+      "from ..git import Commit\n",
+      "from ..models import GitHubCore\n",
+      "from ..decorators import requires_auth\n",
+      "\n",
+      "\n",
+      "class Contents(GitHubCore):\n",
+      "    \"\"\"The :class:`Contents <Contents>` object. It holds the information\n",
+      "    concerning any content in a repository requested via the API.\n",
+      "\n",
+      "    Two content instances can be checked like so::\n",
+      "\n",
+      "        c1 == c2\n",
+      "        c1 != c2\n",
+      "\n",
+      "    And is equivalent to::\n",
+      "\n",
+      "        c1.sha == c2.sha\n",
+      "        c1.sha != c2.sha\n",
+      "\n",
+      "    See also: http://developer.github.com/v3/repos/contents/\n",
+      "    \"\"\"\n",
+      "    def _update_attributes(self, content):\n",
+      "        # links\n",
+      "        self._api = content.get('url')\n",
+      "        #: Dictionary of links\n",
+      "        self.links = content.get('_links')\n",
+      "\n",
+      "        #: URL of the README on github.com\n",
+      "        self.html_url = content.get('html_url')\n",
+      "\n",
+      "        #: URL for the git api pertaining to the README\n",
+      "        self.git_url = content.get('git_url')\n",
+      "\n",
+      "        #: git:// URL of the content if it is a submodule\n",
+      "        self.submodule_git_url = content.get('submodule_git_url')\n",
+      "\n",
+      "        # should always be 'base64'\n",
+      "        #: Returns encoding used on the content.\n",
+      "        self.encoding = content.get('encoding', '')\n",
+      "\n",
+      "        # content, base64 encoded and decoded\n",
+      "        #: Base64-encoded content of the file.\n",
+      "        self.content = content.get('content', '')\n",
+      "\n",
+      "        #: Decoded content of the file as a bytes object. If we try to decode\n",
+      "        #: to character set for you, we might encounter an exception which\n",
+      "        #: will prevent the object from being created. On python2 this is the\n",
+      "        #: same as a string, but on python3 you should call the decode method\n",
+      "        #: with the character set you wish to use, e.g.,\n",
+      "        #: ``content.decoded.decode('utf-8')``.\n",
+      "        #: .. versionchanged:: 0.5.2\n",
+      "        self.decoded = ''\n",
+      "        if self.encoding == 'base64' and self.content:\n",
+      "            self.decoded = b64decode(self.content.encode())\n",
+      "\n",
+      "        # file name, path, and size\n",
+      "        #: Name of the content.\n",
+      "        self.name = content.get('name', '')\n",
+      "        #: Path to the content.\n",
+      "        self.path = content.get('path', '')\n",
+      "        #: Size of the content\n",
+      "        self.size = content.get('size', 0)\n",
+      "        #: SHA string.\n",
+      "        self.sha = content.get('sha', '')\n",
+      "        #: Type of content. ('file', 'symlink', 'submodule')\n",
+      "        self.type = content.get('type', '')\n",
+      "        #: Target will only be set of type is a symlink. This is what the link\n",
+      "        #: points to\n",
+      "        self.target = content.get('target', '')\n",
+      "\n",
+      "        self._uniq = self.sha\n",
+      "\n",
+      "    def _repr(self):\n",
+      "        return '<Content [{0}]>'.format(self.path)\n",
+      "\n",
+      "    def __eq__(self, other):\n",
+      "        return self.decoded == other\n",
+      "\n",
+      "    def __ne__(self, other):\n",
+      "        return self.sha != other\n",
+      "\n",
+      "    @requires_auth\n",
+      "    def delete(self, message, branch=None, committer=None, author=None):\n",
+      "        \"\"\"Delete this file.\n",
+      "\n",
+      "        :param str message: (required), commit message to describe the removal\n",
+      "        :param str branch: (optional), branch where the file exists.\n",
+      "            Defaults to the default branch of the repository.\n",
+      "        :param dict committer: (optional), if no information is given the\n",
+      "            authenticated user's information will be used. You must specify\n",
+      "            both a name and email.\n",
+      "        :param dict author: (optional), if omitted this will be filled in with\n",
+      "            committer information. If passed, you must specify both a name and\n",
+      "            email.\n",
+      "        :returns: dictionary of new content and associated commit\n",
+      "        :rtype: :class:`~github3.repos.contents.Contents` and\n",
+      "            :class:`~github3.git.Commit`\n",
+      "        \"\"\"\n",
+      "        json = {}\n",
+      "        if message:\n",
+      "            data = {'message': message, 'sha': self.sha, 'branch': branch,\n",
+      "                    'committer': validate_commmitter(committer),\n",
+      "                    'author': validate_commmitter(author)}\n",
+      "            self._remove_none(data)\n",
+      "            json = self._json(self._delete(self._api, data=dumps(data)), 200)\n",
+      "            if 'commit' in json:\n",
+      "                json['commit'] = Commit(json['commit'], self)\n",
+      "            if 'content' in json:\n",
+      "                json['content'] = self._instance_or_null(Contents,\n",
+      "                                                         json['content'])\n",
+      "        return json\n",
+      "\n",
+      "    @requires_auth\n",
+      "    def update(self, message, content, branch=None, committer=None,\n",
+      "               author=None):\n",
+      "        \"\"\"Update this file.\n",
+      "\n",
+      "        :param str message: (required), commit message to describe the update\n",
+      "        :param str content: (required), content to update the file with\n",
+      "        :param str branch: (optional), branch where the file exists.\n",
+      "            Defaults to the default branch of the repository.\n",
+      "        :param dict committer: (optional), if no information is given the\n",
+      "            authenticated user's information will be used. You must specify\n",
+      "            both a name and email.\n",
+      "        :param dict author: (optional), if omitted this will be filled in with\n",
+      "            committer information. If passed, you must specify both a name and\n",
+      "            email.\n",
+      "        :returns: dictionary containing the updated contents object and the\n",
+      "            commit in which it was changed.\n",
+      "        :rtype: dictionary of :class:`~github3.repos.contents.Contents` and\n",
+      "            :class:`~github3.git.Commit`\n",
+      "        \"\"\"\n",
+      "        if content and not isinstance(content, bytes):\n",
+      "            raise ValueError(  # (No coverage)\n",
+      "                'content must be a bytes object')  # (No coverage)\n",
+      "\n",
+      "        json = None\n",
+      "        if message and content:\n",
+      "            content = b64encode(content).decode('utf-8')\n",
+      "            data = {'message': message, 'content': content, 'branch': branch,\n",
+      "                    'sha': self.sha,\n",
+      "                    'committer': validate_commmitter(committer),\n",
+      "                    'author': validate_commmitter(author)}\n",
+      "            self._remove_none(data)\n",
+      "            json = self._json(self._put(self._api, data=dumps(data)), 200)\n",
+      "            if 'content' in json:\n",
+      "                self._update_attributes(json['content'])\n",
+      "                json['content'] = self\n",
+      "            if 'commit' in json:\n",
+      "                json['commit'] = Commit(json['commit'], self)\n",
+      "        return json\n",
+      "\n",
+      "\n",
+      "def validate_commmitter(d):\n",
+      "    if d and d.get('name') and d.get('email'):\n",
+      "        return d\n",
+      "    return None\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(contents.decoded)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "github3.py tries to preserve original names of data it receives so that users can access that easily and without having to guess. From here, (if we were logged in) we could easily update or even delete this file altogether."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieving a directory's contents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import github3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "repo = github3.repository('sigmavirus24', 'github3.py')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dir_contents = repo.directory_contents('github3/search/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(u'__init__.py', <Content [github3/search/__init__.py]>),\n",
+       " (u'code.py', <Content [github3/search/code.py]>),\n",
+       " (u'issue.py', <Content [github3/search/issue.py]>),\n",
+       " (u'repository.py', <Content [github3/search/repository.py]>),\n",
+       " (u'user.py', <Content [github3/search/user.py]>)]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dir_contents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dc = dict(dir_contents)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "u''"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dc['user.py'].decoded"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In many instances when GitHub returns more than one instance of a resource, they don't return the entirety of each resource. Here's we have an example of this. The file bodies would be expensive to return for a directory with a lot of files, so GitHub omits them. We can still retrieve it. We just need to make another call to the API for the information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# -*- coding: utf-8 -*-\n",
+      "from __future__ import unicode_literals\n",
+      "\n",
+      "from ..models import GitHubCore\n",
+      "from ..users import User\n",
+      "\n",
+      "\n",
+      "class UserSearchResult(GitHubCore):\n",
+      "    def _update_attributes(self, data):\n",
+      "        result = data.copy()\n",
+      "        #: Score of this search result\n",
+      "        self.score = result.pop('score')\n",
+      "        #: Text matches\n",
+      "        self.text_matches = result.pop('text_matches', [])\n",
+      "        #: User object matching the search\n",
+      "        self.user = User(result, self)\n",
+      "\n",
+      "    def _repr(self):\n",
+      "        return '<UserSearchResult [{0}]>'.format(self.user)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "dc['user.py'].refresh()\n",
+    "print(dc['user.py'].decoded)"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
in example-notebooks, under contents-api.ipynb example, while running line 3:
contents = repo.file_contents('github3/repos/contents.py')
 is throwing error as: AttributeError: 'Repository' object has no attribute 'file_contents'.
'file_contents' should be replaced with 'contents'.
