### PR TITLE
Add sha parameter to Pull Request merge

### DIFF
--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -300,16 +300,18 @@ class PullRequest(GitHubCore):
         return self._iter(int(number), url, IssueComment, etag=etag)
 
     @requires_auth
-    def merge(self, commit_message=''):
+    def merge(self, commit_message='', sha=None):
         """Merge this pull request.
 
         :param str commit_message: (optional), message to be used for the
             merge commit
         :returns: bool
         """
-        data = dumps({'commit_message': commit_message})
+        parameters = {'commit_message': commit_message}
+        if sha:
+            parameters['sha'] = sha
         url = self._build_url('merge', base_url=self._api)
-        json = self._json(self._put(url, data=data), 200)
+        json = self._json(self._put(url, data=dumps(parameters)), 200)
         self.merge_commit_sha = json['sha']
         return json['merged']
 


### PR DESCRIPTION
The Github v3 API supports an optional 'sha' parameter to explicitly
specify the commit that should be at the head of a Pull Request
when merging it.
https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button

Conflicts:
	github3/pulls.py