### PR TITLE
Add support for filtering team/organization members by role

### DIFF
--- a/github3/models.py
+++ b/github3/models.py
@@ -218,7 +218,7 @@ class GitHubCore(GitHubObject):
         self._uri = urlparse(uri)
         self.url = uri
 
-    def _iter(self, count, url, cls, params=None, etag=None):
+    def _iter(self, count, url, cls, params=None, etag=None, headers=None):
         """Generic iterator for this project.
 
         :param int count: How many items to return.
@@ -226,11 +226,12 @@ class GitHubCore(GitHubObject):
         :param class cls: cls to return an object of
         :param params dict: (optional) Parameters for the request
         :param str etag: (optional), ETag from the last call
+        :param dict headers: (optional) HTTP Headers for the request
         :returns: A lazy iterator over the pagianted resource
         :rtype: :class:`GitHubIterator <github3.structs.GitHubIterator>`
         """
         from .structs import GitHubIterator
-        return GitHubIterator(count, url, cls, self, params, etag)
+        return GitHubIterator(count, url, cls, self, params, etag, headers)
 
     @property
     def ratelimit_remaining(self):

--- a/github3/orgs.py
+++ b/github3/orgs.py
@@ -37,22 +37,25 @@ class Team(GitHubCore):
 
     """
 
+    # Roles available to members on a team.
+    members_roles = frozenset(['member', 'maintainer', 'all'])
+
     def _update_attributes(self, team):
         self._api = team.get('url', '')
         #: This team's name.
         self.name = team.get('name')
         #: Unique ID of the team.
         self.id = team.get('id')
-        #: Permission leve of the group
+        #: Permission level of the group.
         self.permission = team.get('permission')
         #: Number of members in this team.
         self.members_count = team.get('members_count')
         members = team.get('members_url')
-        #: Members URL Template. Expands with ``member``
+        #: Members URL Template. Expands with ``member``.
         self.members_urlt = URITemplate(members) if members else None
         #: Number of repos owned by this team.
         self.repos_count = team.get('repos_count')
-        #: Repositories url (not a template)
+        #: Repositories url (not a template).
         self.repositories_url = team.get('repositories_url')
 
     def _repr(self):
@@ -157,7 +160,7 @@ class Team(GitHubCore):
         """
         headers = {}
         params = {}
-        if role in set(["member", "maintainer", "all"]):
+        if role in self.members_roles:
             params['role'] = role
             headers['Accept'] = 'application/vnd.github.ironman-preview+json'
         url = self._build_url('members', base_url=self._api)
@@ -241,6 +244,13 @@ class Organization(BaseAccount):
     See also: http://developer.github.com/v3/orgs/
 
     """
+
+    # Filters available when listing members. Note: ``"2fa_disabled"``
+    # is only available for organization owners.
+    members_filters = frozenset(['2fa_disabled', 'all'])
+
+    # Roles available to members in an organization.
+    members_roles = frozenset(['all', 'admin', 'member'])
 
     def _update_attributes(self, org):
         super(Organization, self)._update_attributes(org)
@@ -470,9 +480,9 @@ class Organization(BaseAccount):
         """
         headers = {}
         params = {}
-        if filter in set(["2fa_disabled", "all"]):
+        if filter in self.members_filters:
             params['filter'] = filter
-        if role in set(["all", "admin", "member"]):
+        if role in self.members_roles:
             params['role'] = role
             headers['Accept'] = 'application/vnd.github.ironman-preview+json'
         url = self._build_url('members', base_url=self._api)

--- a/github3/orgs.py
+++ b/github3/orgs.py
@@ -143,17 +143,25 @@ class Team(GitHubCore):
         return self._boolean(self._get(url), 204, 404)
 
     @requires_auth
-    def members(self, number=-1, etag=None):
+    def members(self, role=None, number=-1, etag=None):
         r"""Iterate over the members of this team.
 
+        :param str role: (optional), filter members returned by their role
+            in the team. Can be one of: ``"member"``, ``"maintainer"``,
+            ``"all"``. Default: ``"all"``.
         :param int number: (optional), number of users to iterate over.
             Default: -1 iterates over all values
         :param str etag: (optional), ETag from a previous request to the same
             endpoint
         :returns: generator of :class:`User <github3.users.User>`\ s
         """
+        headers = {}
+        params = {}
+        if role in set(["member", "maintainer", "all"]):
+            params['role'] = role
+            headers['Accept'] = 'application/vnd.github.ironman-preview+json'
         url = self._build_url('members', base_url=self._api)
-        return self._iter(int(number), url, User, etag=etag)
+        return self._iter(int(number), url, User, etag=etag, headers=headers)
 
     @requires_auth
     def repositories(self, number=-1, etag=None):
@@ -444,24 +452,32 @@ class Organization(BaseAccount):
         url = self._build_url('events', base_url=self._api)
         return self._iter(int(number), url, Event, etag=etag)
 
-    def members(self, filter=None, number=-1, etag=None):
+    def members(self, filter=None, role=None, number=-1, etag=None):
         r"""Iterate over members of this organization.
 
         :param str filter: (optional), filter members returned by this method.
             Can be one of: ``"2fa_disabled"``, ``"all",``. Default: ``"all"``.
             Filtering by ``"2fa_disabled"`` is only available for organization
             owners with private repositories.
+        :param str role: (optional), filter members returned by their role.
+            Can be one of: ``"all"``, ``"admin"``, ``"member"``. Default:
+            ``"all"``.
         :param int number: (optional), number of members to return. Default:
             -1 will return all available.
         :param str etag: (optional), ETag from a previous request to the same
             endpoint
         :returns: generator of :class:`User <github3.users.User>`\ s
         """
+        headers = {}
         params = {}
         if filter in set(["2fa_disabled", "all"]):
             params['filter'] = filter
+        if role in set(["all", "admin", "member"]):
+            params['role'] = role
+            headers['Accept'] = 'application/vnd.github.ironman-preview+json'
         url = self._build_url('members', base_url=self._api)
-        return self._iter(int(number), url, User, params=params, etag=etag)
+        return self._iter(int(number), url, User, params=params, etag=etag,
+                          headers=headers)
 
     def public_members(self, number=-1, etag=None):
         r"""Iterate over public members of this organization.

--- a/github3/orgs.py
+++ b/github3/orgs.py
@@ -164,7 +164,8 @@ class Team(GitHubCore):
             params['role'] = role
             headers['Accept'] = 'application/vnd.github.ironman-preview+json'
         url = self._build_url('members', base_url=self._api)
-        return self._iter(int(number), url, User, etag=etag, headers=headers)
+        return self._iter(int(number), url, User, params=params, etag=etag,
+                          headers=headers)
 
     @requires_auth
     def repositories(self, number=-1, etag=None):

--- a/tests/cassettes/Organization_members_filters.json
+++ b/tests/cassettes/Organization_members_filters.json
@@ -1,0 +1,118 @@
+{
+    "http_interactions": [
+        {
+            "recorded_at": "2014-07-21T02:20:59",
+            "request": {
+                "body": {
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "Accept": "application/vnd.github.v3.full+json",
+                    "Accept-Charset": "utf-8",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Authorization": "Basic <BASIC_AUTH>",
+                    "Content-Type": "application/json",
+                    "User-Agent": "github3.py/1.0.0"
+                },
+                "method": "GET",
+                "uri": "https://api.github.com/orgs/github3py"
+            },
+            "response": {
+                "body": {
+                    "base64_string": "H4sIAAAAAAAAA52SPW/CMBCG/0rlOSROIFB5adcOVRekSl2iS3CMVce2bAdEEf+9ZxJKSie6Jed77+N570iUEVITRoQM276e2wNJiNwQlq8ei7xcJqR3Cp+3IVjPsgysTIfUtDFdZpzw2VTquDW+ukOTnRXYlO+4DvdJBwlqO97V3N0nHjXHbPg4YRnb10o21X+q/ZZOi8IOArhbJOegH1H2nrvG6IAAzlT7bKT/hENp6PjVn/RsECZZ0IdJWBoM12gmYbpXKkFfGwjSRGtfYSO90cnD+0vk3IFER4escezBA1b+IBDSB08YTUhrlDJ7hDv5kxrb4Ns2dOpmscltTM+icRwC31QQcJ6C5sWMlrNitaYLVpRsvvzAwXq7+ZWzmNHVrKDrfMkoZfMi5oSDjTDenAAtv4YFMWoCqMo6iVR5NS6D85m9xp5/45fIdUsE9Fn1HgRWz+kiElYKauMgmHH1WiqFi1cjPyJcCm2bQrRMpZ3UqTC7ZxHpRhPjOSlA/MeLg63jHKPeQoNd5nRVUJzxdrrT6Rvyb5wJlAMAAA==",
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "access-control-allow-credentials": "true",
+                    "access-control-allow-origin": "*",
+                    "access-control-expose-headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+                    "cache-control": "private, max-age=60, s-maxage=60",
+                    "content-encoding": "gzip",
+                    "content-security-policy": "default-src 'none'",
+                    "content-type": "application/json; charset=utf-8",
+                    "date": "Mon, 21 Jul 2014 02:20:58 GMT",
+                    "etag": "\"7a807b488b5268f40ea462dc5a957426\"",
+                    "last-modified": "Sun, 20 Jul 2014 16:00:32 GMT",
+                    "server": "GitHub.com",
+                    "status": "200 OK",
+                    "strict-transport-security": "max-age=31536000; includeSubdomains",
+                    "transfer-encoding": "chunked",
+                    "vary": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding",
+                    "x-content-type-options": "nosniff",
+                    "x-frame-options": "deny",
+                    "x-github-media-type": "github.v3; param=full; format=json",
+                    "x-github-request-id": "48A0C4D3:55C1:7111A9:53CC790A",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4948",
+                    "x-ratelimit-reset": "1405911623",
+                    "x-served-by": "a8d8e492d6966f0c23dee2eed64c678a",
+                    "x-xss-protection": "1; mode=block"
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "url": "https://api.github.com/orgs/github3py"
+            }
+        },
+        {
+            "recorded_at": "2014-07-21T02:20:59",
+            "request": {
+                "body": {
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "Accept": "application/vnd.github.v3.full+json",
+                    "Accept-Charset": "utf-8",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Authorization": "Basic <BASIC_AUTH>",
+                    "Content-Type": "application/json",
+                    "User-Agent": "github3.py/1.0.0"
+                },
+                "method": "GET",
+                "uri": "https://api.github.com/orgs/github3py/members?per_page=100&filter=2fa_disabled"
+            },
+            "response": {
+                "body": {
+                    "base64_string": "H4sIAAAAAAAAA62TXW+CMBSG/wvXxspHFbzZr9jVsphSDtgMKWkLxhH/+07FbJYtxjKvIKTPe14OPG9DUMtKNME2AM24gQ/N8mARiCLYrtOMZuEiYD0zTO06VeOpvTGt3hIyPtTLSph9l3caFJeNgcYsuTyQjozwC0ZV6hpgM4MVUAijgvKkTDOAJKbRpkxXrKAJBZrHCEwGteI6ZEzGSZo4XffmUE/aja0ugHO0lHUtj5gwfZv7Q8g3h/XGe9FUszKQG4g0e8CF4quc7YKENr6FLsxA7GUnCpui8RspKDxLXSmsdGywzUAUtPIS1+WaK9EaIRvfcg6LWVJVrBGfbE4WshojbC3fGhcGWejxt/SFR2ggrRI94ye7EgUcRI8rnhU4oTHPnFpAI17xN7ALFwZ2rDhYF0tWazgvftzUojqwXqhORwmetSZFySqNVzPtHOHfdvIwSWO6LtKszCIK6ywKN2kOEBZZzHi5wdkP2Dlpe9/PyWEvQ2/Z+Y7+kfIfS524f3nqJD3PVDf21nP8vN6uOmm+tjqwv68O/hxjJ40c4x9w9v0LOH8telEHAAA=",
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "access-control-allow-credentials": "true",
+                    "access-control-allow-origin": "*",
+                    "access-control-expose-headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+                    "cache-control": "private, max-age=60, s-maxage=60",
+                    "content-encoding": "gzip",
+                    "content-security-policy": "default-src 'none'",
+                    "content-type": "application/json; charset=utf-8",
+                    "date": "Mon, 21 Jul 2014 02:20:58 GMT",
+                    "etag": "\"b9889daf1e146f0dc5ac6d7f9852a69a\"",
+                    "server": "GitHub.com",
+                    "status": "200 OK",
+                    "strict-transport-security": "max-age=31536000; includeSubdomains",
+                    "transfer-encoding": "chunked",
+                    "vary": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding",
+                    "x-content-type-options": "nosniff",
+                    "x-frame-options": "deny",
+                    "x-github-media-type": "github.v3; param=full; format=json",
+                    "x-github-request-id": "48A0C4D3:55C1:7111DD:53CC790A",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4947",
+                    "x-ratelimit-reset": "1405911623",
+                    "x-served-by": "88d924ed861736d2749ce1a55766cb53",
+                    "x-xss-protection": "1; mode=block"
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "url": "https://api.github.com/orgs/github3py/members?per_page=100"
+            }
+        }
+    ],
+    "recorded_with": "betamax/{version}"
+}

--- a/tests/cassettes/Organization_members_roles.json
+++ b/tests/cassettes/Organization_members_roles.json
@@ -1,0 +1,118 @@
+{
+    "http_interactions": [
+        {
+            "recorded_at": "2014-07-21T02:20:59",
+            "request": {
+                "body": {
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "Accept": "application/vnd.github.v3.full+json",
+                    "Accept-Charset": "utf-8",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Authorization": "Basic <BASIC_AUTH>",
+                    "Content-Type": "application/json",
+                    "User-Agent": "github3.py/1.0.0"
+                },
+                "method": "GET",
+                "uri": "https://api.github.com/orgs/github3py"
+            },
+            "response": {
+                "body": {
+                    "base64_string": "H4sIAAAAAAAAA52SPW/CMBCG/0rlOSROIFB5adcOVRekSl2iS3CMVce2bAdEEf+9ZxJKSie6Jed77+N570iUEVITRoQM276e2wNJiNwQlq8ei7xcJqR3Cp+3IVjPsgysTIfUtDFdZpzw2VTquDW+ukOTnRXYlO+4DvdJBwlqO97V3N0nHjXHbPg4YRnb10o21X+q/ZZOi8IOArhbJOegH1H2nrvG6IAAzlT7bKT/hENp6PjVn/RsECZZ0IdJWBoM12gmYbpXKkFfGwjSRGtfYSO90cnD+0vk3IFER4escezBA1b+IBDSB08YTUhrlDJ7hDv5kxrb4Ns2dOpmscltTM+icRwC31QQcJ6C5sWMlrNitaYLVpRsvvzAwXq7+ZWzmNHVrKDrfMkoZfMi5oSDjTDenAAtv4YFMWoCqMo6iVR5NS6D85m9xp5/45fIdUsE9Fn1HgRWz+kiElYKauMgmHH1WiqFi1cjPyJcCm2bQrRMpZ3UqTC7ZxHpRhPjOSlA/MeLg63jHKPeQoNd5nRVUJzxdrrT6Rvyb5wJlAMAAA==",
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "access-control-allow-credentials": "true",
+                    "access-control-allow-origin": "*",
+                    "access-control-expose-headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+                    "cache-control": "private, max-age=60, s-maxage=60",
+                    "content-encoding": "gzip",
+                    "content-security-policy": "default-src 'none'",
+                    "content-type": "application/json; charset=utf-8",
+                    "date": "Mon, 21 Jul 2014 02:20:58 GMT",
+                    "etag": "\"7a807b488b5268f40ea462dc5a957426\"",
+                    "last-modified": "Sun, 20 Jul 2014 16:00:32 GMT",
+                    "server": "GitHub.com",
+                    "status": "200 OK",
+                    "strict-transport-security": "max-age=31536000; includeSubdomains",
+                    "transfer-encoding": "chunked",
+                    "vary": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding",
+                    "x-content-type-options": "nosniff",
+                    "x-frame-options": "deny",
+                    "x-github-media-type": "github.v3; param=full; format=json",
+                    "x-github-request-id": "48A0C4D3:55C1:7111A9:53CC790A",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4948",
+                    "x-ratelimit-reset": "1405911623",
+                    "x-served-by": "a8d8e492d6966f0c23dee2eed64c678a",
+                    "x-xss-protection": "1; mode=block"
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "url": "https://api.github.com/orgs/github3py"
+            }
+        },
+        {
+            "recorded_at": "2014-07-21T02:20:59",
+            "request": {
+                "body": {
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "Accept": "application/vnd.github.v3.full+json",
+                    "Accept-Charset": "utf-8",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Authorization": "Basic <BASIC_AUTH>",
+                    "Content-Type": "application/json",
+                    "User-Agent": "github3.py/1.0.0"
+                },
+                "method": "GET",
+                "uri": "https://api.github.com/orgs/github3py/members?per_page=100&role=all"
+            },
+            "response": {
+                "body": {
+                    "base64_string": "H4sIAAAAAAAAA62TXW+CMBSG/wvXxspHFbzZr9jVsphSDtgMKWkLxhH/+07FbJYtxjKvIKTPe14OPG9DUMtKNME2AM24gQ/N8mARiCLYrtOMZuEiYD0zTO06VeOpvTGt3hIyPtTLSph9l3caFJeNgcYsuTyQjozwC0ZV6hpgM4MVUAijgvKkTDOAJKbRpkxXrKAJBZrHCEwGteI6ZEzGSZo4XffmUE/aja0ugHO0lHUtj5gwfZv7Q8g3h/XGe9FUszKQG4g0e8CF4quc7YKENr6FLsxA7GUnCpui8RspKDxLXSmsdGywzUAUtPIS1+WaK9EaIRvfcg6LWVJVrBGfbE4WshojbC3fGhcGWejxt/SFR2ggrRI94ye7EgUcRI8rnhU4oTHPnFpAI17xN7ALFwZ2rDhYF0tWazgvftzUojqwXqhORwmetSZFySqNVzPtHOHfdvIwSWO6LtKszCIK6ywKN2kOEBZZzHi5wdkP2Dlpe9/PyWEvQ2/Z+Y7+kfIfS524f3nqJD3PVDf21nP8vN6uOmm+tjqwv68O/hxjJ40c4x9w9v0LOH8telEHAAA=",
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "access-control-allow-credentials": "true",
+                    "access-control-allow-origin": "*",
+                    "access-control-expose-headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+                    "cache-control": "private, max-age=60, s-maxage=60",
+                    "content-encoding": "gzip",
+                    "content-security-policy": "default-src 'none'",
+                    "content-type": "application/json; charset=utf-8",
+                    "date": "Mon, 21 Jul 2014 02:20:58 GMT",
+                    "etag": "\"b9889daf1e146f0dc5ac6d7f9852a69a\"",
+                    "server": "GitHub.com",
+                    "status": "200 OK",
+                    "strict-transport-security": "max-age=31536000; includeSubdomains",
+                    "transfer-encoding": "chunked",
+                    "vary": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding",
+                    "x-content-type-options": "nosniff",
+                    "x-frame-options": "deny",
+                    "x-github-media-type": "github.v3; param=full; format=json",
+                    "x-github-request-id": "48A0C4D3:55C1:7111DD:53CC790A",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4947",
+                    "x-ratelimit-reset": "1405911623",
+                    "x-served-by": "88d924ed861736d2749ce1a55766cb53",
+                    "x-xss-protection": "1; mode=block"
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "url": "https://api.github.com/orgs/github3py/members?per_page=100"
+            }
+        }
+    ],
+    "recorded_with": "betamax/{version}"
+}

--- a/tests/cassettes/Team_members_roles.json
+++ b/tests/cassettes/Team_members_roles.json
@@ -1,0 +1,175 @@
+{
+    "http_interactions": [
+        {
+            "recorded_at": "2014-07-23T01:45:33",
+            "request": {
+                "body": {
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "Accept": "application/vnd.github.v3.full+json",
+                    "Accept-Charset": "utf-8",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Authorization": "Basic <BASIC_AUTH>",
+                    "Content-Type": "application/json",
+                    "User-Agent": "github3.py/1.0.0"
+                },
+                "method": "GET",
+                "uri": "https://api.github.com/orgs/github3py"
+            },
+            "response": {
+                "body": {
+                    "base64_string": "H4sIAAAAAAAAA52SPW/CMBCG/0rlOSROIFB5adcOVRekSl2iS3CMVce2bAdEEf+9ZxJKSie6Jed77+N570iUEVITRoQM276e2wNJiNwQlq8ei7xcJqR3Cp+3IVjPsgysTIfUtDFdZpzw2VTquDW+ukOTnRXYlO+4DvdJBwlqO97V3N0nHjXHbPg4YRnb10o21X+q/ZZOi8IOArhbJOegH1H2nrvG6IAAzlT7bKT/hENp6PjVn/RsECZZ0IdJWBoM12gmYbpXKkFfGwjSRGtfYSO90cnD+0vk3IFER4escezBA1b+IBDSB08YTUhrlDJ7hDv5kxrb4Ns2dOpmscltTM+icRwC31QQcJ6C5sWMlrNitaYLVpRsvvzAwXq7+ZWzmNHVrKDrfMkoZfMi5oSDjTDenAAtv4YFMWoCqMo6iVR5NS6D85m9xp5/45fIdUsE9Fn1HgRWz+kiElYKauMgmHH1WiqFi1cjPyJcCm2bQrRMpZ3UqTC7ZxHpRhPjOSlA/MeLg63jHKPeQoNd5nRVUJzxdrrT6Rvyb5wJlAMAAA==",
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "access-control-allow-credentials": "true",
+                    "access-control-allow-origin": "*",
+                    "access-control-expose-headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+                    "cache-control": "private, max-age=60, s-maxage=60",
+                    "content-encoding": "gzip",
+                    "content-security-policy": "default-src 'none'",
+                    "content-type": "application/json; charset=utf-8",
+                    "date": "Wed, 23 Jul 2014 01:45:33 GMT",
+                    "etag": "\"7a807b488b5268f40ea462dc5a957426\"",
+                    "last-modified": "Sun, 20 Jul 2014 16:00:32 GMT",
+                    "server": "GitHub.com",
+                    "status": "200 OK",
+                    "strict-transport-security": "max-age=31536000; includeSubdomains",
+                    "transfer-encoding": "chunked",
+                    "vary": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding",
+                    "x-content-type-options": "nosniff",
+                    "x-frame-options": "deny",
+                    "x-github-media-type": "github.v3; param=full; format=json",
+                    "x-github-request-id": "48A0C4D3:727F:1A5298:53CF13BD",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4959",
+                    "x-ratelimit-reset": "1406080845",
+                    "x-served-by": "971af40390ac4398fcdd45c8dab0fbe7",
+                    "x-xss-protection": "1; mode=block"
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "url": "https://api.github.com/orgs/github3py"
+            }
+        },
+        {
+            "recorded_at": "2014-07-23T01:45:33",
+            "request": {
+                "body": {
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "Accept": "application/vnd.github.v3.full+json",
+                    "Accept-Charset": "utf-8",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Authorization": "Basic <BASIC_AUTH>",
+                    "Content-Type": "application/json",
+                    "User-Agent": "github3.py/1.0.0"
+                },
+                "method": "GET",
+                "uri": "https://api.github.com/teams/189901"
+            },
+            "response": {
+                "body": {
+                    "base64_string": "H4sIAAAAAAAAA5VTyW7CMBT8lcrnLE4gUHzpuYeqF6RKvURO4gZL3uQFRBH/3kdiREBVCzf7+c1bZsYHpKhkiKD3nWLWoQTxDpHiebXCRYKcCD286fObYVZy57hWEKWd5AoAwQq4bbw3juQ5NTzrud+EJmu1zD2j0uVjPciVTDbQpr4bk0fEIR6OUMQyox332nL2SKUBNpmh1UF52DUWrOO9SpC2PVX8m/ph0QMSuodNCRr3mpn9mablc1lUi38ogGoun0KHQf6m4BqTn0dnW6b8Y9ARci/1N31/Id+ERvC2vkvIm2rX0KmidEs9tbeUDEEX3RQcs61WHggYjBXyYmT/BXaLHo4kZ4NAkGSo2l9ky7iGcANiIqKCEAno2kaN0RvtuNMqefp4hSQmKQdTj1lx7FEDAvaIgZ477xDBCfrSQujd6ftcblxBG3jbeCluFpt8j6ktWsuoZ11NwZSoxEWZ4iotl2s8J2VFZotPGCyY7ipnnuJlWuJ1sSAYk1l5yvF7M3zoqYmPxx8B305P6QMAAA==",
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "access-control-allow-credentials": "true",
+                    "access-control-allow-origin": "*",
+                    "access-control-expose-headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+                    "cache-control": "private, max-age=60, s-maxage=60",
+                    "content-encoding": "gzip",
+                    "content-security-policy": "default-src 'none'",
+                    "content-type": "application/json; charset=utf-8",
+                    "date": "Wed, 23 Jul 2014 01:45:33 GMT",
+                    "etag": "\"a7a21842a7b4f3bff9b46d086d6364aa\"",
+                    "last-modified": "Sat, 20 Oct 2007 11:24:19 GMT",
+                    "server": "GitHub.com",
+                    "status": "200 OK",
+                    "strict-transport-security": "max-age=31536000; includeSubdomains",
+                    "transfer-encoding": "chunked",
+                    "vary": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding",
+                    "x-content-type-options": "nosniff",
+                    "x-frame-options": "deny",
+                    "x-github-media-type": "github.v3; param=full; format=json",
+                    "x-github-request-id": "48A0C4D3:727F:1A52AF:53CF13BD",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4958",
+                    "x-ratelimit-reset": "1406080845",
+                    "x-served-by": "c046d59f93ede9ab52d5ac29f1ed70f7",
+                    "x-xss-protection": "1; mode=block"
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "url": "https://api.github.com/teams/189901"
+            }
+        },
+        {
+            "recorded_at": "2014-07-23T01:45:33",
+            "request": {
+                "body": {
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "Accept": "application/vnd.github.v3.full+json",
+                    "Accept-Charset": "utf-8",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Authorization": "Basic <BASIC_AUTH>",
+                    "Content-Type": "application/json",
+                    "User-Agent": "github3.py/1.0.0"
+                },
+                "method": "GET",
+                "uri": "https://api.github.com/teams/189901/members?per_page=100&role=all"
+            },
+            "response": {
+                "body": {
+                    "base64_string": "H4sIAAAAAAAAA52Ty26DMBBF/8XrKA6PJMAmX9FVVSFjBhgJbGQbohTl3zsGVKlsKliBkM+Z64v9ObFW16hYxizWnRjRDDaM2YlhybIwviTR5cTEKJww+WBaWtc419uM8+WjPdfomqEYLBiplQPlzlJ3fOAL/CBVbVaBdzIZxEl0vZVJWqXhFW5pGNyTAiAo00jI6k7AZlCP65DFTJMs36RtXNdu8i25ZmSzuNJtq59k2e7ov0H8l6SQyzuq+qCFyIlr1wAVS1t6+6LQuv2hZmri/pFj6T2W/paBcnewlaNYT0WJJm6g17NwKKw02DvUan/APzTZtKmFwm9xzEa0JYmPtj/KTBENIx3U/fiCTbw3OAr58tUYkIAjlX1QueHJ6F490D35oEPhq0cHuSg7f0cr0Vp4f/0A/p8Y7LUDAAA=",
+                    "encoding": "utf-8",
+                    "string": ""
+                },
+                "headers": {
+                    "access-control-allow-credentials": "true",
+                    "access-control-allow-origin": "*",
+                    "access-control-expose-headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+                    "cache-control": "private, max-age=60, s-maxage=60",
+                    "content-encoding": "gzip",
+                    "content-security-policy": "default-src 'none'",
+                    "content-type": "application/json; charset=utf-8",
+                    "date": "Wed, 23 Jul 2014 01:45:33 GMT",
+                    "etag": "\"6e61732b48fdd33d664a49419e6ae91c\"",
+                    "server": "GitHub.com",
+                    "status": "200 OK",
+                    "strict-transport-security": "max-age=31536000; includeSubdomains",
+                    "transfer-encoding": "chunked",
+                    "vary": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding",
+                    "x-content-type-options": "nosniff",
+                    "x-frame-options": "deny",
+                    "x-github-media-type": "github.v3; param=full; format=json",
+                    "x-github-request-id": "48A0C4D3:727F:1A52C2:53CF13BD",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4957",
+                    "x-ratelimit-reset": "1406080845",
+                    "x-served-by": "62a1303ae95931e56e387e87d354bb24",
+                    "x-xss-protection": "1; mode=block"
+                },
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "url": "https://api.github.com/teams/189901/members?per_page=100"
+            }
+        }
+    ],
+    "recorded_with": "betamax/{version}"
+}

--- a/tests/integration/test_orgs.py
+++ b/tests/integration/test_orgs.py
@@ -128,6 +128,31 @@ class TestOrganization(IntegrationHelper):
             for member in o.members():
                 assert isinstance(member, github3.users.User)
 
+    @pytest.mark.xfail(reason="sigmavirus24 needs to actually write a test for this.")
+    def test_can_filter_organization_members(self):
+        """
+        Test the ability to filter an organization's members by
+        their ``"2fa_disabled"`` status. This filter is only
+        available to organization owners.
+        """
+        self.basic_login()
+        cassette_name = self.cassette_name('members_filters')
+        with self.recorder.use_cassette(cassette_name):
+            o = self.get_organization()
+
+            for member in o.members(filter='2fa_disabled'):
+                assert isinstance(member, github3.users.User)
+
+    def test_can_filter_members_by_role(self):
+        """Test the ability to filter an organization's members by role."""
+        self.basic_login()
+        cassette_name = self.cassette_name('members_roles')
+        with self.recorder.use_cassette(cassette_name):
+            o = self.get_organization()
+
+            for member in o.members(role='all'):
+                assert isinstance(member, github3.users.User)
+
     def test_public_members(self):
         """Test the ability to retrieve an organization's public members."""
         self.basic_login()

--- a/tests/integration/test_orgs_team.py
+++ b/tests/integration/test_orgs_team.py
@@ -87,8 +87,17 @@ class TestTeam(IntegrationHelper):
         cassette_name = self.cassette_name('members')
         with self.recorder.use_cassette(cassette_name):
             t = self.get_team()
-            for user in t.members():
-                assert isinstance(user, github3.users.User)
+            for member in t.members():
+                assert isinstance(member, github3.users.User)
+
+    def test_can_filter_members_by_role(self):
+        """Test the ability to filter an team's members by role."""
+        self.basic_login()
+        cassette_name = self.cassette_name('members_roles')
+        with self.recorder.use_cassette(cassette_name):
+            t = self.get_team()
+            for member in t.members(role='all'):
+                assert isinstance(member, github3.users.User)
 
     def test_repositories(self):
         """Show that a user can retrieve a team's repositories."""

--- a/tests/unit/test_orgs.py
+++ b/tests/unit/test_orgs.py
@@ -273,6 +273,28 @@ class TestOrganizationIterator(UnitIteratorHelper):
             headers={}
         )
 
+    def test_members_filters(self):
+        """Show that one can iterate over all members with 2fa_disabled."""
+        i = self.instance.members(filter='2fa_disabled')
+        self.get_next(i)
+
+        self.session.get.assert_called_once_with(
+            url_for('members'),
+            params={'per_page': 100, 'filter': '2fa_disabled'},
+            headers={}
+        )
+
+    def test_members_roles(self):
+        """Show that one can iterate over all admins."""
+        i = self.instance.members(role='admin')
+        self.get_next(i)
+
+        self.session.get.assert_called_once_with(
+            url_for('members'),
+            params={'per_page': 100, 'role': 'admin'},
+            headers={u'Accept': u'application/vnd.github.ironman-preview+json'}
+        )
+
     def test_public_members(self):
         """Show that one can iterate over all public members."""
         i = self.instance.public_members()

--- a/tests/unit/test_orgs.py
+++ b/tests/unit/test_orgs.py
@@ -284,6 +284,17 @@ class TestOrganizationIterator(UnitIteratorHelper):
             headers={}
         )
 
+    def test_members_excludes_fake_filters(self):
+        """Show that one cannot pass a bogus filter to the API."""
+        i = self.instance.members(filter='bogus-filter')
+        self.get_next(i)
+
+        self.session.get.assert_called_once_with(
+            url_for('members'),
+            params={'per_page': 100},
+            headers={}
+        )
+
     def test_members_roles(self):
         """Show that one can iterate over all admins."""
         i = self.instance.members(role='admin')
@@ -293,6 +304,17 @@ class TestOrganizationIterator(UnitIteratorHelper):
             url_for('members'),
             params={'per_page': 100, 'role': 'admin'},
             headers={'Accept': 'application/vnd.github.ironman-preview+json'}
+        )
+
+    def test_members_excludes_fake_roles(self):
+        """Show that one cannot pass a bogus role to the API."""
+        i = self.instance.members(role='bogus-role')
+        self.get_next(i)
+
+        self.session.get.assert_called_once_with(
+            url_for('members'),
+            params={'per_page': 100},
+            headers={}
         )
 
     def test_public_members(self):

--- a/tests/unit/test_orgs.py
+++ b/tests/unit/test_orgs.py
@@ -292,7 +292,7 @@ class TestOrganizationIterator(UnitIteratorHelper):
         self.session.get.assert_called_once_with(
             url_for('members'),
             params={'per_page': 100, 'role': 'admin'},
-            headers={u'Accept': u'application/vnd.github.ironman-preview+json'}
+            headers={'Accept': 'application/vnd.github.ironman-preview+json'}
         )
 
     def test_public_members(self):

--- a/tests/unit/test_orgs_team.py
+++ b/tests/unit/test_orgs_team.py
@@ -157,6 +157,17 @@ class TestTeamIterator(UnitIteratorHelper):
             headers={}
         )
 
+    def test_members_roles(self):
+        """Show that one can iterate of all maintainers of a Team."""
+        i = self.instance.members(role='maintainer')
+        self.get_next(i)
+
+        self.session.get.assert_called_once_with(
+            url_for('members'),
+            params={'per_page': 100, 'role': 'maintainer'},
+            headers={u'Accept': u'application/vnd.github.ironman-preview+json'}
+        )
+
     def test_members_requires_auth(self):
         """Show that one needs to authenticate to get team members."""
         self.session.has_auth.return_value = False

--- a/tests/unit/test_orgs_team.py
+++ b/tests/unit/test_orgs_team.py
@@ -165,7 +165,7 @@ class TestTeamIterator(UnitIteratorHelper):
         self.session.get.assert_called_once_with(
             url_for('members'),
             params={'per_page': 100, 'role': 'maintainer'},
-            headers={u'Accept': u'application/vnd.github.ironman-preview+json'}
+            headers={'Accept': 'application/vnd.github.ironman-preview+json'}
         )
 
     def test_members_requires_auth(self):

--- a/tests/unit/test_orgs_team.py
+++ b/tests/unit/test_orgs_team.py
@@ -168,6 +168,17 @@ class TestTeamIterator(UnitIteratorHelper):
             headers={'Accept': 'application/vnd.github.ironman-preview+json'}
         )
 
+    def test_members_excludes_fake_roles(self):
+        """Show that one cannot pass a bogus role to the API."""
+        i = self.instance.members(role='bogus-role')
+        self.get_next(i)
+
+        self.session.get.assert_called_once_with(
+            url_for('members'),
+            params={'per_page': 100},
+            headers={}
+        )
+
     def test_members_requires_auth(self):
         """Show that one needs to authenticate to get team members."""
         self.session.has_auth.return_value = False


### PR DESCRIPTION
Takes advantage of some of the improved organization permissions. In particular:

 * The List team members API accepts an optional role parameter, allowing you to fetch only maintainers or only regular members.

* The organization Members list API now accepts a role parameter, so that you can request to see only the owners (or non-owners) of your organization.

Wasn't sure if this is something you want to add to github3.py yet, as these API calls are available in preview mode (requires submitting a custom HTTP Accept header).