### PR TITLE
Fix to repo.create_status default arguments

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -98,3 +98,5 @@ Contributors
 - Nolan Bruabker (@nrb)
 
 - Marcin Wielgoszewski (@mwielgoszewski)
+
+- Omri Harel (@omriharel)

--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -940,7 +940,7 @@ class Repository(GitHubCore):
 
     @requires_auth
     def create_status(self, sha, state, target_url=None, description=None,
-                      context=None):
+                      context='default'):
         """Create a status object on a commit.
 
         :param str sha: (required), SHA of the commit to create the status on


### PR DESCRIPTION
It would result in a 422 validation error if we passed no context, so I changed the default context to 'default' as specified in GitHub's API - https://developer.github.com/v3/repos/statuses/#create-a-status