### PR TITLE
Use released packages for dev-dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,5 @@
 mock==1.0.1
 pytest>=2.3.5
 wheel==0.21.0
-git+git://github.com/sigmavirus24/betamax
-git+git://github.com/sigmavirus24/betamax_matchers
+betamax>=0.5.0
+betamax_matchers>=0.2.0


### PR DESCRIPTION
This fixes tests execution hanging because of tox trying to clone repositories it does not have access to.

I had to make this change to properly run the tests and I think that all the contributors except @sigmavirus24 have to also make this change. It should also be backward compatible for you.

Comments are welcomed :)