### PR TITLE
Return correct permissions information for teams when using ironman-preview

### DIFF
--- a/github3/orgs.py
+++ b/github3/orgs.py
@@ -178,8 +178,10 @@ class Team(GitHubCore):
         :returns: generator of :class:`Repository <github3.repos.Repository>`
             objects
         """
+        headers = {'Accept': 'application/vnd.github.ironman-preview+json'}
         url = self._build_url('repos', base_url=self._api)
-        return self._iter(int(number), url, Repository, etag=etag)
+        return self._iter(int(number), url, Repository, etag=etag,
+                          headers=headers)
 
     @requires_auth
     def membership_for(self, username):

--- a/tests/unit/test_orgs_team.py
+++ b/tests/unit/test_orgs_team.py
@@ -194,5 +194,5 @@ class TestTeamIterator(UnitIteratorHelper):
         self.session.get.assert_called_once_with(
             url_for('repos'),
             params={'per_page': 100},
-            headers={}
+            headers={'Accept': 'application/vnd.github.ironman-preview+json'}
         )


### PR DESCRIPTION
When using the new GitHub organisational model (https://developer.github.com/changes/2015-06-24-api-enhancements-for-working-with-organization-permissions/), the GitHub API returns stale information about permissions granted on repositories by teams, unless the `Accept: application/vnd.github.ironman-preview.repository+json` header is added to the API request.  This PR resolves this.