### PR TITLE
Improve error message when creating a token fails.

### DIFF
--- a/github3/exceptions.py
+++ b/github3/exceptions.py
@@ -26,6 +26,10 @@ class GitHubError(Exception):
                                     self.msg or self.code)
 
     def __str__(self):
+        if self.errors:
+            error = self.errors[0]
+            return ('{0} {1}: {resource} {field} {code}'
+                    .format(self.code, self.msg, **error))
         return '{0} {1}'.format(self.code, self.msg)
 
     @property

--- a/github3/github.py
+++ b/github3/github.py
@@ -192,7 +192,10 @@ class GitHub(GitHubCore):
                 data['scopes'] = scopes
 
             with self.session.temporary_basic_auth(username, password):
-                json = self._json(self._post(url, data=data), 201)
+                try:
+                    json = self._json(self._post(url, data=data), 201)
+                except Exception as e:
+                    raise KeyError('Failed to create a token: {}'.format(e))
 
         return self._instance_or_null(Authorization, json)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,7 +49,7 @@ class TestGitHubError(TestCase):
         super(TestGitHubError, self).__init__(methodName)
         self.r = requests.Response()
         self.r.status_code = 400
-        message = '{"message": "m", "errors": ["e"]}'
+        message = '{"message": "m"}'
         self.r.raw = RequestsBytesIO(message.encode() if is_py3 else message)
         self.error = github3.GitHubError(self.r)
 
@@ -58,6 +58,15 @@ class TestGitHubError(TestCase):
 
     def test_str(self):
         assert str(self.error) == '400 m'
+
+    def test_str_detailed(self):
+        r = requests.Response()
+        r.status_code = 400
+        message = ('{"message": "m", "errors": [{"field": "description", '
+                   '"code": "already_exists", "resource": "OauthAccess"}]}')
+        r.raw = RequestsBytesIO(message.encode() if is_py3 else message)
+        error = github3.GitHubError(r)
+        assert str(error) == '400 m: OauthAccess description already_exists'
 
     def test_message(self):
         assert self.error.message == self.error.msg


### PR DESCRIPTION
Before:

	Traceback (most recent call last):
	  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
	    "__main__", fname, loader, pkg_name)
	  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
	    exec code in run_globals
	  File "/home/chris/projects/2004/boxi/bee3/bee3/__main__.py", line 23, in <module>
	    main()
	  File "/home/chris/projects/2004/boxi/bee3/bee3/__main__.py", line 16, in main
	    commands.init(args)
	  File "bee3/commands.py", line 6, in init
	    auth = authorize(args.username, args.password, ['repo'], note, note_url)
	  File "/home/chris/projects/2004/boxi/bee3/ve/local/lib/python2.7/site-packages/github3/api.py", line 38, in authorize
	    client_secret)
	  File "/home/chris/projects/2004/boxi/bee3/ve/local/lib/python2.7/site-packages/github3/github.py", line 121, in authorize
	    json = self._json(self._post(url, data=data), 201)
	  File "/home/chris/projects/2004/boxi/bee3/ve/local/lib/python2.7/site-packages/github3/models.py", line 100, in _json
	    if self._boolean(response, status_code, 404) and response.content:
	  File "/home/chris/projects/2004/boxi/bee3/ve/local/lib/python2.7/site-packages/github3/models.py", line 121, in _boolean
	    raise GitHubError(response)
	github3.models.GitHubError: 422 Validation Failed

After:

	KeyError: u'Failed to create a token: 422 Validation Failed: OauthAccess description already_exists'
