### PR TITLE
Expose the rate limit that's sent along in the headers

### DIFF
--- a/github3/gists/gist.py
+++ b/github3/gists/gist.py
@@ -110,11 +110,11 @@ class Gist(GitHubCore):
         :returns: :class:`GistComment <github3.gists.comment.GistComment>`
 
         """
-        json = None
+        data = None
         if body:
             url = self._build_url('comments', base_url=self._api)
-            json = self._json(self._post(url, data={'body': body}), 201)
-        return self._instance_or_null(GistComment, json)
+            data = self._post(url, data={'body': body})
+        return self._instance_or_null(GistComment, data, 201)
 
     @requires_auth
     def delete(self):
@@ -159,8 +159,7 @@ class Gist(GitHubCore):
 
         """
         url = self._build_url('forks', base_url=self._api)
-        json = self._json(self._post(url), 201)
-        return self._instance_or_null(Gist, json)
+        return self._instance_or_null(Gist, self._post(url), 201)
 
     @requires_auth
     def is_starred(self):

--- a/github3/gists/history.py
+++ b/github3/gists/history.py
@@ -63,5 +63,4 @@ class GistHistory(GitHubCore):
 
         """
         from .gist import Gist
-        json = self._json(self._get(self._api), 200)
-        return self._instance_or_null(Gist, json)
+        return self._instance_or_null(Gist, self._get(self._api), 200)

--- a/github3/github.py
+++ b/github3/github.py
@@ -365,8 +365,6 @@ class GitHub(GitHubCore):
         """
         url = self._build_url('feeds')
         json = self._json(self._get(url), 200)
-        del json['ETag']
-        del json['Last-Modified']
 
         urls = [
             'timeline_url', 'user_url', 'current_user_public_url',

--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -1835,10 +1835,6 @@ class Repository(GitHubCore):
         if resp.status_code == 202:
             return {}
         json = self._json(resp, 200)
-        if json.get('ETag'):
-            del json['ETag']
-        if json.get('Last-Modified'):
-            del json['Last-Modified']
         return json
 
 

--- a/github3/structs.py
+++ b/github3/structs.py
@@ -85,10 +85,6 @@ class GitHubIterator(models.GitHubCore, collections.Iterator):
                         "GitHub's API returned a body that could not be"
                         " handled", json
                     )
-                if json.get('ETag'):
-                    del json['ETag']
-                if json.get('Last-Modified'):
-                    del json['Last-Modified']
                 json = json.items()
 
             for i in json:


### PR DESCRIPTION
GitHub sends along information about the rate limit in every response.
To avoid calling the rate limit API very often, let's expose this
information in the returned object.

Could this one be cherry-picked into a 0.9 release too if you're planning to
make another one?