### PR TITLE
Expose the original response that was used for creating GitHubObjects

### DIFF
--- a/github3/gists/gist.py
+++ b/github3/gists/gist.py
@@ -110,11 +110,11 @@ class Gist(GitHubCore):
         :returns: :class:`GistComment <github3.gists.comment.GistComment>`
 
         """
-        json = None
+        response = None
         if body:
             url = self._build_url('comments', base_url=self._api)
-            json = self._json(self._post(url, data={'body': body}), 201)
-        return self._instance_or_null(GistComment, json)
+            response = self._post(url, data={'body': body})
+        return self._instance_or_null(GistComment, response, 201)
 
     @requires_auth
     def delete(self):
@@ -159,8 +159,7 @@ class Gist(GitHubCore):
 
         """
         url = self._build_url('forks', base_url=self._api)
-        json = self._json(self._post(url), 201)
-        return self._instance_or_null(Gist, json)
+        return self._instance_or_null(Gist, self._post(url), 201)
 
     @requires_auth
     def is_starred(self):

--- a/github3/gists/history.py
+++ b/github3/gists/history.py
@@ -63,5 +63,4 @@ class GistHistory(GitHubCore):
 
         """
         from .gist import Gist
-        json = self._json(self._get(self._api), 200)
-        return self._instance_or_null(Gist, json)
+        return self._instance_or_null(Gist, self._get(self._api), 200)

--- a/github3/git.py
+++ b/github3/git.py
@@ -211,9 +211,8 @@ class Tree(GitData):
 
         :returns: :class:`Tree <Tree>`
         """
-        json = self._json(self._get(self._api, params={'recursive': '1'}),
-                          200)
-        return self._instance_or_null(Tree, json)
+        response = self._get(self._api, params={'recursive': '1'})
+        return self._instance_or_null(Tree, response, 200)
 
 
 class Hash(GitHubObject):

--- a/github3/github.py
+++ b/github3/github.py
@@ -143,11 +143,11 @@ class GitHub(GitHubCore):
         :param int id_num: (required), unique id of the authorization
         :returns: :class:`Authorization <Authorization>`
         """
-        json = None
+        response = None
         if int(id_num) > 0:
             url = self._build_url('authorizations', str(id_num))
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Authorization, json)
+            response = self._get(url)
+        return self._instance_or_null(Authorization, response, 200)
 
     @requires_basic_auth
     def authorizations(self, number=-1, etag=None):
@@ -182,7 +182,7 @@ class GitHub(GitHubCore):
             for which to create the token
         :returns: :class:`Authorization <Authorization>`
         """
-        json = None
+        response = None
 
         if username and password:
             url = self._build_url('authorizations')
@@ -192,9 +192,9 @@ class GitHub(GitHubCore):
                 data['scopes'] = scopes
 
             with self.session.temporary_basic_auth(username, password):
-                json = self._json(self._post(url, data=data), 201)
+                response = self._post(url, data=data)
 
-        return self._instance_or_null(Authorization, json)
+        return self._instance_or_null(Authorization, response, 201)
 
     def check_authorization(self, access_token):
         """Check an authorization created by a registered application.
@@ -232,8 +232,8 @@ class GitHub(GitHubCore):
         new_gist = {'description': description, 'public': public,
                     'files': files}
         url = self._build_url('gists')
-        json = self._json(self._post(url, data=new_gist), 201)
-        return self._instance_or_null(Gist, json)
+        response = self._post(url, data=new_gist)
+        return self._instance_or_null(Gist, response, 201)
 
     @requires_auth
     def create_issue(self, owner, repository, title, body=None, assignee=None,
@@ -291,13 +291,12 @@ class GitHub(GitHubCore):
             or file-like object
         :returns: :class:`Key <github3.users.Key>`
         """
-        json = None
+        response = None
 
         if title and key:
             url = self._build_url('user', 'keys')
-            req = self._post(url, data={'title': title, 'key': key})
-            json = self._json(req, 201)
-        return self._instance_or_null(Key, json)
+            response = self._post(url, data={'title': title, 'key': key})
+        return self._instance_or_null(Key, response, 201)
 
     @requires_auth
     def create_repository(self, name, description='', homepage='',
@@ -327,8 +326,8 @@ class GitHub(GitHubCore):
                 'has_issues': has_issues, 'has_wiki': has_wiki,
                 'auto_init': auto_init,
                 'gitignore_template': gitignore_template}
-        json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(Repository, json)
+        response = self._post(url, data=data)
+        return self._instance_or_null(Repository, response, 201)
 
     @requires_auth
     def emails(self, number=-1, etag=None):
@@ -365,8 +364,6 @@ class GitHub(GitHubCore):
         """
         url = self._build_url('feeds')
         json = self._json(self._get(url), 200)
-        del json['ETag']
-        del json['Last-Modified']
 
         urls = [
             'timeline_url', 'user_url', 'current_user_public_url',
@@ -471,8 +468,7 @@ class GitHub(GitHubCore):
         :returns: :class:`Gist <github3.gists.Gist>`
         """
         url = self._build_url('gists', str(id_num))
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(Gist, json)
+        return self._instance_or_null(Gist, self._get(url), 200)
 
     @requires_auth
     def gists(self, number=-1, etag=None):
@@ -559,12 +555,12 @@ class GitHub(GitHubCore):
         :param int number: (required), issue number
         :return: :class:`Issue <github3.issues.Issue>`
         """
-        json = None
+        response = None
         if username and repository and int(number) > 0:
             url = self._build_url('repos', username, repository, 'issues',
                                   str(number))
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Issue, json)
+            response = self._get(url)
+        return self._instance_or_null(Issue, response, 200)
 
     @requires_auth
     def issues(self, filter='', state='', labels='', sort='', direction='',
@@ -652,11 +648,11 @@ class GitHub(GitHubCore):
         :param int id_num: (required), unique id of the key
         :returns: :class:`Key <github3.users.Key>`
         """
-        json = None
+        response = None
         if int(id_num) > 0:
             url = self._build_url('user', 'keys', str(id_num))
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Key, json)
+            response = self._get(url)
+        return self._instance_or_null(Key, response, 200)
 
     @requires_auth
     def keys(self, number=-1, etag=None):
@@ -740,16 +736,14 @@ class GitHub(GitHubCore):
         :rtype: :class:`User <github3.users.User>`
         """
         url = self._build_url('user')
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(User, json)
+        return self._instance_or_null(User, self._get(url), 200)
 
     @requires_auth
     def membership_in(self, organization):
         """Retrieve the user's membership in the specified organization."""
         url = self._build_url('user', 'memberships', 'orgs',
                               str(organization))
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(Membership, json)
+        return self._instance_or_null(Membership, self._get(url), 200)
 
     def meta(self):
         """Returns a dictionary with arrays of addresses in CIDR format
@@ -802,8 +796,7 @@ class GitHub(GitHubCore):
         :returns: :class:`Organization <github3.orgs.Organization>`
         """
         url = self._build_url('orgs', username)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(Organization, json)
+        return self._instance_or_null(Organization, self._get(url), 200)
 
     @requires_auth
     def organization_issues(self, name, filter='', state='', labels='',
@@ -943,12 +936,12 @@ class GitHub(GitHubCore):
         :param int number: (required), issue number
         :return: :class:`~github.pulls.PullRequest`
         """
-        json = None
+        response = None
         if int(number) > 0:
             url = self._build_url('repos', owner, repository, 'pulls',
                                   str(number))
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(PullRequest, json)
+            response = self._get(url)
+        return self._instance_or_null(PullRequest, response, 200)
 
     def rate_limit(self):
         """Returns a dictionary with information from /rate_limit.
@@ -1054,11 +1047,11 @@ class GitHub(GitHubCore):
         :param str repository: (required)
         :returns: :class:`Repository <github3.repos.Repository>`
         """
-        json = None
+        response = None
         if owner and repository:
             url = self._build_url('repos', owner, repository)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Repository, json)
+            response = self._get(url)
+        return self._instance_or_null(Repository, response, 200)
 
     def repository_with_id(self, number):
         """Returns the Repository with id ``number``.
@@ -1067,11 +1060,11 @@ class GitHub(GitHubCore):
         :returns: :class:`Repository <github3.repos.Repository>`
         """
         number = int(number)
-        json = None
+        response = None
         if number > 0:
             url = self._build_url('repositories', str(number))
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Repository, json)
+            response = self._get(url)
+        return self._instance_or_null(Repository, response, 200)
 
     @requires_app_credentials
     def revoke_authorization(self, access_token):
@@ -1519,8 +1512,7 @@ class GitHub(GitHubCore):
         :returns: :class:`User <github3.users.User>`
         """
         url = self._build_url('users', username)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(User, json)
+        return self._instance_or_null(User, self._get(url), 200)
 
     @requires_auth
     def user_issues(self, filter='', state='', labels='', sort='',
@@ -1585,11 +1577,11 @@ class GitHub(GitHubCore):
         :returns: :class:`User <github3.users.User>`
         """
         number = int(number)
-        json = None
+        response = None
         if number > 0:
             url = self._build_url('user', str(number))
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(User, json)
+            response = self._get(url)
+        return self._instance_or_null(User, response, 200)
 
     def zen(self):
         """Returns a quote from the Zen of GitHub. Yet another API Easter Egg

--- a/github3/issues/issue.py
+++ b/github3/issues/issue.py
@@ -147,13 +147,13 @@ class Issue(GitHubCore):
         :param int id_num: (required), comment id, see example above
         :returns: :class:`IssueComment <github3.issues.comment.IssueComment>`
         """
-        json = None
+        response = None
         if int(id_num) > 0:  # Might as well check that it's positive
             owner, repo = self.repository
             url = self._build_url('repos', owner, repo, 'issues', 'comments',
                                   str(id_num))
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(IssueComment, json)
+            response = self._get(url)
+        return self._instance_or_null(IssueComment, response, 200)
 
     def comments(self, number=-1, sort='', direction='', since=None):
         """Iterate over the comments on this issue.
@@ -182,12 +182,11 @@ class Issue(GitHubCore):
         :param str body: (required), comment body
         :returns: :class:`IssueComment <github3.issues.comment.IssueComment>`
         """
-        json = None
+        response = None
         if body:
             url = self._build_url('comments', base_url=self._api)
-            json = self._json(self._post(url, data={'body': body}),
-                              201)
-        return self._instance_or_null(IssueComment, json)
+            response = self._post(url, data={'body': body})
+        return self._instance_or_null(IssueComment, response, 201)
 
     @requires_auth
     def edit(self, title=None, body=None, assignee=None, state=None,
@@ -258,11 +257,11 @@ class Issue(GitHubCore):
         :returns: :class:`~github3.pulls.PullRequest`
         """
         from .. import pulls
-        json = None
+        response = None
         pull_request_url = self.pull_request_urls.get('url')
         if pull_request_url:
-            json = self._json(self._get(pull_request_url), 200)
-        return self._instance_or_null(pulls.PullRequest, json)
+            response = self._get(pull_request_url)
+        return self._instance_or_null(pulls.PullRequest, response, 200)
 
     @requires_auth
     def remove_label(self, name):

--- a/github3/notifications.py
+++ b/github3/notifications.py
@@ -89,8 +89,8 @@ class Thread(GitHubCore):
         """
         url = self._build_url('subscription', base_url=self._api)
         sub = {'subscribed': subscribed, 'ignored': ignored}
-        json = self._json(self._put(url, data=dumps(sub)), 200)
-        return self._instance_or_null(Subscription, json)
+        response = self._put(url, data=dumps(sub))
+        return self._instance_or_null(Subscription, response, 200)
 
     def subscription(self):
         """Checks the status of the user's subscription to this thread.
@@ -98,8 +98,7 @@ class Thread(GitHubCore):
         :returns: :class:`Subscription <Subscription>`
         """
         url = self._build_url('subscription', base_url=self._api)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(Subscription, json)
+        return self._instance_or_null(Subscription, self._get(url), 200)
 
 
 class Subscription(GitHubCore):

--- a/github3/orgs.py
+++ b/github3/orgs.py
@@ -369,8 +369,7 @@ class Organization(BaseAccount):
                 'gitignore_template': gitignore_template}
         if int(team_id) > 0:
             data.update({'team_id': team_id})
-        json = self._json(self._post(url, data), 201)
-        return self._instance_or_null(Repository, json)
+        return self._instance_or_null(Repository, self._post(url, data), 201)
 
     @requires_auth
     def conceal_member(self, username):
@@ -405,8 +404,7 @@ class Organization(BaseAccount):
         data = {'name': name, 'repo_names': repo_names,
                 'permission': permission}
         url = self._build_url('teams', base_url=self._api)
-        json = self._json(self._post(url, data), 201)
-        return self._instance_or_null(Team, json)
+        return self._instance_or_null(Team, self._post(url, data), 201)
 
     @requires_auth
     def edit(self, billing_email=None, company=None, email=None, location=None,
@@ -575,11 +573,11 @@ class Organization(BaseAccount):
         :param int team_id: (required), unique id for the team
         :returns: :class:`Team <Team>`
         """
-        json = None
+        response = None
         if int(team_id) > 0:
             url = self._build_url('teams', str(team_id))
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Team, json)
+            response = self._get(url)
+        return self._instance_or_null(Team, response, 200)
 
 
 class Membership(GitHubCore):

--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -90,8 +90,8 @@ class PullFile(models.GitHubCore):
 
         :returns: :class:`Contents <github3.repos.contents.Contents>`
         """
-        json = self._json(self._get(self.contents_url), 200)
-        return self._instance_or_null(Contents, json)
+        response = self._get(self.contents_url)
+        return self._instance_or_null(Contents, response, 200)
 
 
 class PullRequest(models.GitHubCore):
@@ -216,10 +216,10 @@ class PullRequest(models.GitHubCore):
         :returns: :class:`IssueComment <github3.issues.comment.IssueComment>`
         """
         url = self.comments_url
-        json = None
+        response = None
         if body:
-            json = self._json(self._post(url, data={'body': body}), 201)
-        return self._instance_or_null(IssueComment, json)
+            response = self._post(url, data={'body': body})
+        return self._instance_or_null(IssueComment, response, 201)
 
     @requires_auth
     def create_review_comment(self, body, commit_id, path, position):
@@ -237,8 +237,8 @@ class PullRequest(models.GitHubCore):
         url = self._build_url('comments', base_url=self._api)
         data = {'body': body, 'commit_id': commit_id, 'path': path,
                 'position': int(position)}
-        json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(ReviewComment, json)
+        response = self._post(url, data=data)
+        return self._instance_or_null(ReviewComment, response, 201)
 
     def diff(self):
         """Return the diff.
@@ -262,8 +262,7 @@ class PullRequest(models.GitHubCore):
 
         :returns: :class:`~github3.issues.Issue`
         """
-        json = self._json(self._get(self.issue_url), 200)
-        return self._instance_or_null(Issue, json)
+        return self._instance_or_null(Issue, self._get(self.issue_url), 200)
 
     def commits(self, number=-1, etag=None):
         r"""Iterate over the commits on this pull request.
@@ -436,7 +435,8 @@ class ReviewComment(models.BaseComment):
         url = self._build_url('comments', base_url=self.pull_request_url)
         index = self._api.rfind('/') + 1
         in_reply_to = self._api[index:]
-        json = self._json(self._post(url, data={
-            'body': body, 'in_reply_to': in_reply_to
-        }), 201)
-        return self._instance_or_null(ReviewComment, json)
+        response = self._post(url, data={
+            'body': body,
+            'in_reply_to': in_reply_to
+        })
+        return self._instance_or_null(ReviewComment, response, 201)

--- a/github3/repos/deployment.py
+++ b/github3/repos/deployment.py
@@ -57,16 +57,15 @@ class Deployment(GitHubCore):
         :param str description: A short description of the status. Default: ''.
         :return: partial :class:`DeploymentStatus <DeploymentStatus>`
         """
-        json = None
+        response = None
 
         if state in ('pending', 'success', 'error', 'failure'):
             data = {'state': state, 'target_url': target_url,
                     'description': description}
             self._remove_none(data)
             response = self._post(self.statuses_url, data=data)
-            json = self._json(response, 201)
 
-        return self._instance_or_null(DeploymentStatus, json)
+        return self._instance_or_null(DeploymentStatus, response, 201)
 
     def statuses(self, number=-1, etag=None):
         """Iterate over the deployment statuses for this deployment.

--- a/github3/repos/release.py
+++ b/github3/repos/release.py
@@ -61,13 +61,13 @@ class Release(GitHubCore):
         :param int asset_id: ID of the Asset to retrieve
         :returns: :class:`~github3.repos.release.Asset`
         """
-        json = None
+        response = None
         if int(asset_id) > 0:
             i = self._api.rfind('/')
             url = self._build_url('assets', str(asset_id),
                                   base_url=self._api[:i])
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Asset, json)
+            response = self._get(url)
+        return self._instance_or_null(Asset, response, 200)
 
     def assets(self, number=-1, etag=None):
         """Iterate over the assets available for this release.

--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -302,11 +302,11 @@ class Repository(GitHubCore):
 
     def _create_pull(self, data):
         self._remove_none(data)
-        json = None
+        response = None
         if data:
             url = self._build_url('pulls', base_url=self._api)
-            json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(PullRequest, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(PullRequest, response, 201)
 
     @requires_auth
     def add_collaborator(self, username):
@@ -354,13 +354,12 @@ class Repository(GitHubCore):
         :param int id: (required), id of the asset
         :returns: :class:`Asset <github3.repos.release.Asset>`
         """
-        data = None
+        response = None
         if int(id) > 0:
             url = self._build_url('releases', 'assets', str(id),
                                   base_url=self._api)
-            data = self._json(self._get(url, headers=Release.CUSTOM_HEADERS),
-                              200)
-        return self._instance_or_null(Asset, data)
+            response = self._get(url, headers=Release.CUSTOM_HEADERS)
+        return self._instance_or_null(Asset, response, 200)
 
     def assignees(self, number=-1, etag=None):
         r"""Iterate over all assignees to which an issue may be assigned.
@@ -382,8 +381,7 @@ class Repository(GitHubCore):
             None
         """
         url = self._build_url('git', 'blobs', sha, base_url=self._api)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(Blob, json)
+        return self._instance_or_null(Blob, self._get(url), 200)
 
     def branch(self, name):
         """Get the branch ``name`` of this repository.
@@ -392,11 +390,11 @@ class Repository(GitHubCore):
         :type name: str
         :returns: :class:`Branch <github3.repos.branch.Branch>`
         """
-        json = None
+        response = None
         if name:
             url = self._build_url('branches', name, base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Branch, json)
+            response = self._get(url)
+        return self._instance_or_null(Branch, response, 200)
 
     def branches(self, number=-1, etag=None):
         r"""Iterate over the branches in this repository.
@@ -470,8 +468,7 @@ class Repository(GitHubCore):
             successful, otherwise None
         """
         url = self._build_url('commits', sha, base_url=self._api)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(RepoCommit, json)
+        return self._instance_or_null(RepoCommit, self._get(url), 200)
 
     def commit_activity(self, number=-1, etag=None):
         """Iterate over last year of commit activity by week.
@@ -502,8 +499,7 @@ class Repository(GitHubCore):
             successful, otherwise None
         """
         url = self._build_url('comments', str(comment_id), base_url=self._api)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(RepoComment, json)
+        return self._instance_or_null(RepoComment, self._get(url), 200)
 
     def commits(self, sha=None, path=None, author=None, number=-1, etag=None,
                 since=None, until=None):
@@ -549,8 +545,7 @@ class Repository(GitHubCore):
         """
         url = self._build_url('compare', base + '...' + head,
                               base_url=self._api)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(Comparison, json)
+        return self._instance_or_null(Comparison, self._get(url), 200)
 
     def contributor_statistics(self, number=-1, etag=None):
         """Iterate over the contributors list.
@@ -623,15 +618,15 @@ class Repository(GitHubCore):
             successful, otherwise None
 
         """
-        json = None
+        response = None
         if body and sha and (line and int(line) > 0):
             data = {'body': body, 'line': line, 'path': path,
                     'position': position}
             self._remove_none(data)
             url = self._build_url('commits', sha, 'comments',
                                   base_url=self._api)
-            json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(RepoComment, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(RepoComment, response, 201)
 
     @requires_auth
     def create_commit(self, message, tree, parents, author={}, committer={}):
@@ -654,13 +649,13 @@ class Repository(GitHubCore):
         :returns: :class:`Commit <github3.git.Commit>` if successful, else
             None
         """
-        json = None
+        response = None
         if message and tree and isinstance(parents, list):
             url = self._build_url('git', 'commits', base_url=self._api)
             data = {'message': message, 'tree': tree, 'parents': parents,
                     'author': author, 'committer': committer}
-            json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(Commit, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(Commit, response, 201)
 
     @requires_auth
     def create_deployment(self, ref, force=False, payload='',
@@ -680,16 +675,15 @@ class Repository(GitHubCore):
             environment (e.g., production, staging, qa). Default: "production"
         :returns: :class:`Deployment <github3.repos.deployment.Deployment>`
         """
-        json = None
+        response = None
         if ref:
             url = self._build_url('deployments', base_url=self._api)
             data = {'ref': ref, 'force': force, 'payload': payload,
                     'auto_merge': auto_merge, 'description': description,
                     'environment': environment}
             self._remove_none(data)
-            json = self._json(self._post(url, data=data),
-                              201)
-        return self._instance_or_null(Deployment, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(Deployment, response, 201)
 
     @requires_auth
     def create_file(self, path, message, content, branch=None,
@@ -746,8 +740,7 @@ class Repository(GitHubCore):
         else:
             resp = self._post(url)
 
-        json = self._json(resp, 202)
-        return self._instance_or_null(Repository, json)
+        return self._instance_or_null(Repository, resp, 202)
 
     @requires_auth
     def create_hook(self, name, config, events=['push'], active=True):
@@ -796,13 +789,13 @@ class Repository(GitHubCore):
         issue = {'title': title, 'body': body, 'assignee': assignee,
                  'milestone': milestone, 'labels': labels}
         self._remove_none(issue)
-        json = None
+        response = None
 
         if issue:
             url = self._build_url('issues', base_url=self._api)
-            json = self._json(self._post(url, data=issue), 201)
+            response = self._post(url, data=issue)
 
-        return self._instance_or_null(Issue, json)
+        return self._instance_or_null(Issue, response, 201)
 
     @requires_auth
     def create_key(self, title, key):
@@ -812,12 +805,12 @@ class Repository(GitHubCore):
         :param str key: (required), key text
         :returns: :class:`Key <github3.users.Key>` if successful, else None
         """
-        json = None
+        response = None
         if title and key:
             data = {'title': title, 'key': key}
             url = self._build_url('keys', base_url=self._api)
-            json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(Key, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(Key, response, 201)
 
     @requires_auth
     def create_label(self, name, color):
@@ -829,12 +822,12 @@ class Repository(GitHubCore):
         :returns: :class:`Label <github3.issues.label.Label>` if successful,
             else None
         """
-        json = None
+        response = None
         if name and color:
             data = {'name': name, 'color': color.strip('#')}
             url = self._build_url('labels', base_url=self._api)
-            json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(Label, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(Label, response, 201)
 
     @requires_auth
     def create_milestone(self, title, state=None, description=None,
@@ -855,10 +848,10 @@ class Repository(GitHubCore):
         data = {'title': title, 'state': state,
                 'description': description, 'due_on': due_on}
         self._remove_none(data)
-        json = None
+        response = None
         if data:
-            json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(Milestone, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(Milestone, response, 201)
 
     @requires_auth
     def create_pull(self, title, base, head, body=None):
@@ -901,12 +894,12 @@ class Repository(GitHubCore):
         :returns: :class:`Reference <github3.git.Reference>` if successful
             else None
         """
-        json = None
+        response = None
         if ref and ref.count('/') >= 2 and sha:
             data = {'ref': ref, 'sha': sha}
             url = self._build_url('git', 'refs', base_url=self._api)
-            json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(Reference, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(Reference, response, 201)
 
     @requires_auth
     def create_release(self, tag_name, target_commitish=None, name=None,
@@ -933,10 +926,8 @@ class Repository(GitHubCore):
         self._remove_none(data)
 
         url = self._build_url('releases', base_url=self._api)
-        json = self._json(self._post(
-            url, data=data, headers=Release.CUSTOM_HEADERS
-            ), 201)
-        return self._instance_or_null(Release, json)
+        response = self._post(url, data=data, headers=Release.CUSTOM_HEADERS)
+        return self._instance_or_null(Release, response, 201)
 
     @requires_auth
     def create_status(self, sha, state, target_url=None, description=None,
@@ -953,14 +944,14 @@ class Repository(GitHubCore):
         :returns: the status created if successful
         :rtype: :class:`~github3.repos.status.Status`
         """
-        json = {}
+        response = None
         if sha and state:
             data = {'state': state, 'target_url': target_url,
                     'description': description, 'context': context}
             url = self._build_url('statuses', sha, base_url=self._api)
             self._remove_none(data)
-            json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(Status, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(Status, response, 201)
 
     @requires_auth
     def create_tag(self, tag, message, sha, obj_type, tagger,
@@ -983,15 +974,15 @@ class Repository(GitHubCore):
         if lightweight and tag and sha:
             return self.create_ref('refs/tags/' + tag, sha)
 
-        json = None
+        response = None
         if tag and message and sha and obj_type and len(tagger) == 3:
             data = {'tag': tag, 'message': message, 'object': sha,
                     'type': obj_type, 'tagger': tagger}
             url = self._build_url('git', 'tags', base_url=self._api)
-            json = self._json(self._post(url, data=data), 201)
-            if json:
+            response = self._post(url, data=data)
+            if response.status_code == 201:
                 self.create_ref('refs/tags/' + tag, sha)
-        return self._instance_or_null(Tag, json)
+        return self._instance_or_null(Tag, response, 201)
 
     @requires_auth
     def create_tree(self, tree, base_tree=None):
@@ -1004,14 +995,14 @@ class Repository(GitHubCore):
             to update with new data
         :returns: :class:`Tree <github3.git.Tree>` if successful, else None
         """
-        json = None
+        response = None
         if tree and isinstance(tree, list):
             data = {'tree': tree}
             if base_tree:
                 data['base_tree'] = base_tree
             url = self._build_url('git', 'trees', base_url=self._api)
-            json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(Tree, json)
+            response = self._post(url, data=data)
+        return self._instance_or_null(Tree, response, 201)
 
     @requires_auth
     def delete(self):
@@ -1047,11 +1038,11 @@ class Repository(GitHubCore):
         :param int id: (required), id for deployments.
         :returns: :class:`~github3.repos.deployment.Deployment`
         """
-        json = None
+        response = None
         if int(id) > 0:
             url = self._build_url('deployments', str(id), base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Deployment, json)
+            response = self._get(url)
+        return self._instance_or_null(Deployment, response, 200)
 
     def deployments(self, number=-1, etag=None):
         r"""Iterate over deployments for this repository.
@@ -1164,8 +1155,8 @@ class Repository(GitHubCore):
         :rtype: :class:`~github3.repos.contents.Contents`
         """
         url = self._build_url('contents', path, base_url=self._api)
-        json = self._json(self._get(url, params={'ref': ref}), 200)
-        return self._instance_or_null(Contents, json)
+        response = self._get(url, params={'ref': ref})
+        return self._instance_or_null(Contents, response, 200)
 
     def forks(self, sort='', number=-1, etag=None):
         """Iterate over forks of this repository.
@@ -1191,11 +1182,11 @@ class Repository(GitHubCore):
         :returns: :class:`Commit <github3.git.Commit>` if successful,
             otherwise None
         """
-        json = {}
+        response = None
         if sha:
             url = self._build_url('git', 'commits', sha, base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Commit, json)
+            response = self._get(url)
+        return self._instance_or_null(Commit, response, 200)
 
     @requires_auth
     def hook(self, hook_id):
@@ -1205,11 +1196,11 @@ class Repository(GitHubCore):
         :returns: :class:`Hook <github3.repos.hook.Hook>` if successful,
             otherwise None
         """
-        json = None
+        response = None
         if int(hook_id) > 0:
             url = self._build_url('hooks', str(hook_id), base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Hook, json)
+            response = self._get(url)
+        return self._instance_or_null(Hook, response, 200)
 
     @requires_auth
     def hooks(self, number=-1, etag=None):
@@ -1235,8 +1226,8 @@ class Repository(GitHubCore):
         :returns: :class:`Subscription <github3.notifications.Subscription>`
         """
         url = self._build_url('subscription', base_url=self._api)
-        json = self._json(self._put(url, data=dumps({'ignored': True})), 200)
-        return self._instance_or_null(Subscription, json)
+        response = self._put(url, data=dumps({'ignored': True}))
+        return self._instance_or_null(Subscription, response, 200)
 
     def is_assignee(self, username):
         """Check if the user can be assigned an issue on this repository.
@@ -1270,11 +1261,11 @@ class Repository(GitHubCore):
         :returns: :class:`Issue <github3.issues.issue.Issue>` if successful,
             otherwise None
         """
-        json = None
+        response = None
         if int(number) > 0:
             url = self._build_url('issues', str(number), base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Issue, json)
+            response = self._get(url)
+        return self._instance_or_null(Issue, response, 200)
 
     def issue_events(self, number=-1, etag=None):
         r"""Iterate over issue events on this repository.
@@ -1359,11 +1350,11 @@ class Repository(GitHubCore):
         :returns: :class:`Label <github3.issues.label.Label>` if successful,
             else None
         """
-        json = None
+        response = None
         if name:
             url = self._build_url('labels', name, base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Label, json)
+            response = self._get(url)
+        return self._instance_or_null(Label, response, 200)
 
     def labels(self, number=-1, etag=None):
         r"""Iterate over labels on this repository.
@@ -1396,8 +1387,7 @@ class Repository(GitHubCore):
         :returns: :class:`PagesBuild <github3.repos.pages.PagesBuild>`
         """
         url = self._build_url('pages', 'builds', 'latest', base_url=self._api)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(PagesBuild, json)
+        return self._instance_or_null(PagesBuild, self._get(url), 200)
 
     @requires_auth
     def mark_notifications(self, last_read=''):
@@ -1429,8 +1419,8 @@ class Repository(GitHubCore):
         data = {'base': base, 'head': head}
         if message:
             data['commit_message'] = message
-        json = self._json(self._post(url, data=data), 201)
-        return self._instance_or_null(RepoCommit, json)
+        response = self._post(url, data=data)
+        return self._instance_or_null(RepoCommit, response, 201)
 
     def milestone(self, number):
         """Get the milestone indicated by ``number``.
@@ -1438,12 +1428,12 @@ class Repository(GitHubCore):
         :param int number: (required), unique id number of the milestone
         :returns: :class:`Milestone <github3.issues.milestone.Milestone>`
         """
-        json = None
+        response = None
         if int(number) > 0:
             url = self._build_url('milestones', str(number),
                                   base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Milestone, json)
+            response = self._get(url)
+        return self._instance_or_null(Milestone, response, 200)
 
     def milestones(self, state=None, sort=None, direction=None, number=-1,
                    etag=None):
@@ -1520,8 +1510,7 @@ class Repository(GitHubCore):
         :returns: :class:`PagesInfo <github3.repos.pages.PagesInfo>`
         """
         url = self._build_url('pages', base_url=self._api)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(PagesInfo, json)
+        return self._instance_or_null(PagesInfo, self._get(url), 200)
 
     @requires_auth
     def pages_builds(self, number=-1, etag=None):
@@ -1539,11 +1528,11 @@ class Repository(GitHubCore):
         :param int number: (required), number of the pull request.
         :returns: :class:`PullRequest <github3.pulls.PullRequest>`
         """
-        json = None
+        response = None
         if int(number) > 0:
             url = self._build_url('pulls', str(number), base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(PullRequest, json)
+            response = self._get(url)
+        return self._instance_or_null(PullRequest, response, 200)
 
     def pull_requests(self, state=None, head=None, base=None, sort='created',
                       direction='desc', number=-1, etag=None):
@@ -1593,8 +1582,7 @@ class Repository(GitHubCore):
         :returns: :class:`Contents <github3.repos.contents.Contents>`
         """
         url = self._build_url('readme', base_url=self._api)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(Contents, json)
+        return self._instance_or_null(Contents, self._get(url), 200)
 
     def ref(self, ref):
         """Get a reference pointed to by ``ref``.
@@ -1607,11 +1595,11 @@ class Repository(GitHubCore):
         :param str ref: (required)
         :returns: :class:`Reference <github3.git.Reference>`
         """
-        json = None
+        response = None
         if ref:
             url = self._build_url('git', 'refs', ref, base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Reference, json)
+            response = self._get(url)
+        return self._instance_or_null(Reference, response, 200)
 
     def refs(self, subspace='', number=-1, etag=None):
         r"""Iterate over references for this repository.
@@ -1636,11 +1624,11 @@ class Repository(GitHubCore):
         :param int id: (required), id of release
         :returns: :class:`Release <github3.repos.release.Release>`
         """
-        json = None
+        response = None
         if int(id) > 0:
             url = self._build_url('releases', str(id), base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Release, json)
+            response = self._get(url)
+        return self._instance_or_null(Release, response, 200)
 
     def releases(self, number=-1, etag=None):
         r"""Iterate over releases for this repository.
@@ -1719,9 +1707,8 @@ class Repository(GitHubCore):
         :returns: :class:`Subscription <github3.notifications.Subscription>`
         """
         url = self._build_url('subscription', base_url=self._api)
-        json = self._json(self._put(url, data=dumps({'subcribed': True})),
-                          200)
-        return self._instance_or_null(Subscription, json)
+        response = self._put(url, data=dumps({'subcribed': True}))
+        return self._instance_or_null(Subscription, response, 200)
 
     def subscribers(self, number=-1, etag=None):
         r"""Iterate over users subscribed to this repository.
@@ -1742,8 +1729,7 @@ class Repository(GitHubCore):
         :returns: :class:`Subscription <github3.notifications.Subscription>`
         """
         url = self._build_url('subscription', base_url=self._api)
-        json = self._json(self._get(url), 200)
-        return self._instance_or_null(Subscription, json)
+        return self._instance_or_null(Subscription, self._get(url), 200)
 
     def tag(self, sha):
         """Get an annotated tag.
@@ -1753,11 +1739,11 @@ class Repository(GitHubCore):
         :param str sha: (required), sha of the object for this tag
         :returns: :class:`Tag <github3.git.Tag>`
         """
-        json = None
+        response = None
         if sha:
             url = self._build_url('git', 'tags', sha, base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Tag, json)
+            response = self._get(url)
+        return self._instance_or_null(Tag, response, 200)
 
     def tags(self, number=-1, etag=None):
         r"""Iterate over tags on this repository.
@@ -1791,11 +1777,11 @@ class Repository(GitHubCore):
         :param str sha: (required), sha of the object for this tree
         :returns: :class:`Tree <github3.git.Tree>`
         """
-        json = None
+        response = None
         if sha:
             url = self._build_url('git', 'trees', sha, base_url=self._api)
-            json = self._json(self._get(url), 200)
-        return self._instance_or_null(Tree, json)
+            response = self._get(url)
+        return self._instance_or_null(Tree, response, 200)
 
     @requires_auth
     def update_label(self, name, color, new_name=''):
@@ -1835,10 +1821,6 @@ class Repository(GitHubCore):
         if resp.status_code == 202:
             return {}
         json = self._json(resp, 200)
-        if json.get('ETag'):
-            del json['ETag']
-        if json.get('Last-Modified'):
-            del json['Last-Modified']
         return json
 
 

--- a/github3/structs.py
+++ b/github3/structs.py
@@ -88,7 +88,10 @@ class GitHubIterator(models.GitHubCore, collections.Iterator):
                 json = json.items()
 
             for i in json:
-                yield cls(i)
+                inst = cls(i)
+                if isinstance(inst, models.GitHubObject):
+                    inst.response = response
+                yield inst
                 self.count -= 1 if self.count > 0 else 0
                 if self.count == 0:
                     break

--- a/github3/structs.py
+++ b/github3/structs.py
@@ -85,10 +85,6 @@ class GitHubIterator(models.GitHubCore, collections.Iterator):
                         "GitHub's API returned a body that could not be"
                         " handled", json
                     )
-                if json.get('ETag'):
-                    del json['ETag']
-                if json.get('Last-Modified'):
-                    del json['Last-Modified']
                 json = json.items()
 
             for i in json:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,14 +21,10 @@ class TestGitHubCore(BaseCase):
 
     def test_json(self):
         r = requests.Response()
-        r.headers['Last-Modified'] = 'foo'
-        r.headers['ETag'] = 'bar'
         r.raw = RequestsBytesIO('{}'.encode() if is_py3 else '{}')
         r.status_code = 200
 
         json = self.g._json(r, 200)
-        assert json['Last-Modified'] == 'foo'
-        assert json['ETag'] == 'bar'
 
     def test_boolean(self):
         r = requests.Response()

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -634,7 +634,6 @@ class TestRepository(BaseCase):
 
     def test_weekly_commit_count(self):
         self.response('weekly_commit_count', ETag='"foobarbogus"')
-        self.request.return_value.headers['Last-Modified'] = 'foo'
         self.get(self.api + 'stats/participation')
 
         w = self.repo.weekly_commit_count()


### PR DESCRIPTION
Based on the ideas in #436, this series exposes the original HTTP response
objects, so it can be used to look at things like ETag and rate limits. The
first commit is just to make travis happy, as the notebook test is broken, the
code is not. The second commit is the main body of work, converting
GitHubObject, _instance_or_null and all callers of the latter to pass response
objects around.

The third commit also attaches response objects to GitHubObjects created by
GitHubIterators. I'm not entirely sure this is a good idea, as these responses
contain more data than just the object that was created.
