### PR TITLE
PullRequest: Get full info from detail URL

### DIFF
--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -113,6 +113,8 @@ class PullRequest(models.GitHubCore):
 
     def _update_attributes(self, pull):
         self._api = pull.get('url', '')
+        pull = self._json(self._get(self._api), 200)
+
         #: Base of the merge
         self.base = PullDestination(pull.get('base'), 'Base')
         #: Body of the pull request message


### PR DESCRIPTION
because [`/repos/:owner/:repo/pulls/:number`](https://developer.github.com/v3/pulls/#get-a-single-pull-request) contains fields that [`/repos/:owner/:repo/pulls`](https://developer.github.com/v3/pulls/#list-pull-requests) doesn't have:

``` python
In [11]: pulls_url = 'https://api.github.com/repos/sigmavirus24/github3.py/pulls'

In [12]: set(requests.get(pulls_url + '/439').json().keys()) - \
   ....: set(requests.get(pulls_url).json()[0].keys())
Out[12]:
{u'additions',
 u'changed_files',
 u'comments',
 u'commits',
 u'deletions',
 u'mergeable',
 u'mergeable_state',
 u'merged',
 u'merged_by',
 u'review_comments'}
```

Take this program:

``` python
import github3
gh = github3.GitHub()
repo = gh.repository('sigmavirus24', 'github3.py')
pr = list(repo.pull_requests())[0]
print(pr.number, pr.title, pr.mergeable, pr.mergeable_state)
```

Without this PR, result is:

```
$ python test_GH-441.py
(442, u'PullRequest: Get full info from detail URL', False, u'')
```

With this PR, result is:

```
$ python test_GH-441.py
(442, u'PullRequest: Get full info from detail URL', True, u'unstable')
```

Fixes: GH-441
