### PR TITLE
Correctly get the commit's message

### DIFF
--- a/github3/repos/commit.py
+++ b/github3/repos/commit.py
@@ -63,6 +63,9 @@ class RepoCommit(models.BaseCommit):
 
         self._uniq = self.sha
 
+        #: The commit message
+        self.message = self.commit.message
+
     def _repr(self):
         return '<Repository Commit [{0}]>'.format(self.sha[:7])
 


### PR DESCRIPTION
This patch exposes the commit's message from the "internal" commit. Should fix #330.