### PR TITLE
Clarify documentation around repo filtering

### DIFF
--- a/github3/github.py
+++ b/github3/github.py
@@ -976,7 +976,7 @@ class GitHub(GitHubCore):
     @requires_auth
     def repositories(self, type=None, sort=None, direction=None, number=-1,
                      etag=None):
-        """List public repositories for the authenticated user.
+        """List repositories for the authenticated user, filterable by ``type``.
 
         .. versionchanged:: 0.6
 


### PR DESCRIPTION
This doesn't just list public repos, it also lists repos by other filters, so clarify this in the description.

This addresses issue #455.