### PR TITLE
Remove ETag fields from emoji response, fixes #358

### DIFF
--- a/github3/github.py
+++ b/github3/github.py
@@ -355,7 +355,10 @@ class GitHub(GitHubCore):
                 }
         """
         url = self._build_url('emojis')
-        return self._json(self._get(url), 200)
+        data = self._json(self._get(url), 200)
+        del data['ETag']
+        del data['Last-Modified']
+        return data
 
     @requires_basic_auth
     def feeds(self):

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -95,6 +95,15 @@ class TestGitHub(IntegrationHelper):
         # Asserts that it's a string and looks ilke the URLs we expect to see
         assert emojis['+1'].startswith('https://github')
 
+    def test_emojis_etag(self):
+        """Test the ability to retrieve from /emojis."""
+        cassette_name = self.cassette_name('emojis')
+        with self.recorder.use_cassette(cassette_name):
+            emojis = self.gh.emojis()
+
+        assert 'ETag' not in emojis
+        assert 'Last-Modified' not in emojis
+
     def test_feeds(self):
         """Test the ability to retrieve a user's timelime URLs."""
         self.basic_login()


### PR DESCRIPTION
I'm a bit unsure what to do with [this unittest](https://github.com/sigmavirus24/github3.py/blob/develop/tests%2Funit%2Ftest_github.py#L113) as it'll fail since the response returns `None`. Should I set `self.session.get.return_value` to a valid JSON string? Then it's pretty much the same as the integration tests though.