### PR TITLE
Set Contents.decoded and .content to None by default

### DIFF
--- a/github3/repos/contents.py
+++ b/github3/repos/contents.py
@@ -53,7 +53,7 @@ class Contents(GitHubCore):
 
         # content, base64 encoded and decoded
         #: Base64-encoded content of the file.
-        self.content = content.get('content', '')
+        self.content = content.get('content')
 
         #: Decoded content of the file as a bytes object. If we try to decode
         #: to character set for you, we might encounter an exception which
@@ -62,7 +62,7 @@ class Contents(GitHubCore):
         #: with the character set you wish to use, e.g.,
         #: ``content.decoded.decode('utf-8')``.
         #: .. versionchanged:: 0.5.2
-        self.decoded = b''
+        self.decoded = self.content
         if self.encoding == 'base64' and self.content:
             self.decoded = b64decode(self.content.encode())
 

--- a/tests/integration/test_repos_repo.py
+++ b/tests/integration/test_repos_repo.py
@@ -200,6 +200,17 @@ class TestRepository(helper.IntegrationHelper):
             assert content.name == filename
             assert isinstance(content, github3.repos.contents.Contents)
 
+    def test_directory_contents_content(self):
+        """Tests the content/decoded attributes of a directory's file content"""
+        cassette_name = self.cassette_name('directory_contents')
+        with self.recorder.use_cassette(cassette_name):
+            repository = self.gh.repository('sigmavirus24', 'github3.py')
+            contents = repository.directory_contents('github3/search/')
+
+        for (filename, content) in contents:
+            assert content.content is None
+            assert content.decoded is None
+
     def test_events(self):
         """Test that a user can iterate over the events from a repository."""
         cassette_name = self.cassette_name('events')
@@ -220,6 +231,16 @@ class TestRepository(helper.IntegrationHelper):
             contents = repository.file_contents('github3/repos/repo.py')
 
         assert isinstance(contents, github3.repos.contents.Contents)
+
+    def test_file_contents_content(self):
+        """Tests that the content and decoded attributes of a file is set"""
+        cassette_name = self.cassette_name('file_contents')
+        with self.recorder.use_cassette(cassette_name):
+            repository = self.gh.repository('sigmavirus24', 'github3.py')
+            contents = repository.file_contents('github3/repos/repo.py')
+
+        assert contents.content is not None
+        assert contents.decoded is not None
 
     def test_forks(self):
         """Test that a user can iterate over the forks of a repository."""


### PR DESCRIPTION
Maybe a bit overkill with the integration tests.