### PR TITLE
Release missing a download feature

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -106,3 +106,5 @@ Contributors
 - Sourav Singh(@souravsingh)
 
 - Matt Chung (@itsmemattchung)
+
+- Bastien Gandouet (@b4stien)

--- a/github3/repos/release.py
+++ b/github3/repos/release.py
@@ -73,13 +73,10 @@ class Release(GitHubCore):
 
         """
         resp = None
-        if format == 'tarball':
-            resp = self._get(self.tarball_url, allow_redirects=True,
-                             stream=True)
-
-        elif format == 'zipball':
-            resp = self._get(self.zipball_url, allow_redirects=True,
-                             stream=True)
+        if format in ('tarball', 'zipball'):
+            repo_url = self._api[:self._api.rfind('/releases')]
+            url = self._build_url(format, self.tag_name, base_url=repo_url)
+            resp = self._get(url, allow_redirects=True, stream=True)
 
         if resp and self._boolean(resp, 200, 404):
             utils.stream_response_to_file(resp, path)

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -951,3 +951,50 @@ class TestAsset(BaseCase):
         self.response('', 404)
         self.request.side_effect = None
         assert self.asset.download() is False
+
+
+class TestRelease(BaseCase):
+    def __init__(self, methodName='runTest'):
+        super(TestRelease, self).__init__(methodName)
+        self.release = repos.release.Release(load('release'))
+
+    def test_archive(self):
+        headers = {'content-disposition': 'filename=foo'}
+        self.response('archive', 200, **headers)
+        self.get('https://api.github.com/repos/sigmavirus24/github3.py/tarball/v0.7.1')
+        self.conf.update({'stream': True})
+
+        assert self.release.archive(None) is False
+
+        assert os.path.isfile('foo') is False
+        assert self.release.archive('tarball')
+        assert os.path.isfile('foo')
+        os.unlink('foo')
+        self.mock_assertions()
+
+        self.request.return_value.raw.seek(0)
+        self.request.return_value._content_consumed = False
+
+        assert os.path.isfile('path_to_file') is False
+        assert self.release.archive('tarball', 'path_to_file')
+        assert os.path.isfile('path_to_file')
+        os.unlink('path_to_file')
+
+        self.request.return_value.raw.seek(0)
+        self.request.return_value._content_consumed = False
+
+        self.get('https://api.github.com/repos/sigmavirus24/github3.py/zipball/v0.7.1')
+        assert self.release.archive('zipball')
+        os.unlink('foo')
+
+        self.request.return_value.raw.seek(0)
+        self.request.return_value._content_consumed = False
+
+        o = mock.mock_open()
+        with mock.patch('{0}.open'.format(__name__), o, create=True):
+            with open('archive', 'wb+') as fd:
+                self.release.archive('tarball', fd)
+
+        o.assert_called_once_with('archive', 'wb+')
+        fd = o()
+        fd.write.assert_called_once_with(b'archive_data')


### PR DESCRIPTION
GitHub's response contains two links to download a tarball or a zipball of a given release but this feature is not available in github3.py (see https://developer.github.com/v3/repos/releases/#get-a-single-release).

Would you consider a PR adding this possibility? (following the structure of `Repository.archive()` for instance)