### PR TITLE
Add check for null Milestone creator

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -106,3 +106,5 @@ Contributors
 - Sourav Singh(@souravsingh)
 
 - Matt Chung (@itsmemattchung)
+
+- Chris Thompson (@notyetsecure)

--- a/github3/issues/milestone.py
+++ b/github3/issues/milestone.py
@@ -26,7 +26,9 @@ class Milestone(GitHubCore):
         self.description = mile.get('description')
         #: :class:`User <github3.users.User>` object representing the creator
         #: of the milestone.
-        self.creator = User(mile.get('creator'), self)
+        self.creator = None
+        if mile.get('creator'):
+            self.creator = User(mile.get('creator'), self)
         #: Number of issues associated with this milestone which are still
         #: open.
         self.open_issues = mile.get('open_issues')

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -121,6 +121,12 @@ class TestMilestone(BaseCase):
                              '2013-12-31T23:59:59Z')
         self.mock_assertions()
 
+    def test_issue_464(self):
+        json = self.m.as_dict().copy()
+        json['creator'] = None
+        m = Milestone(json)
+        assert m.creator is None
+
 
 class TestIssue(BaseCase):
     def __init__(self, methodName='runTest'):

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -121,7 +121,7 @@ class TestMilestone(BaseCase):
                              '2013-12-31T23:59:59Z')
         self.mock_assertions()
 
-    def test_issue_464(self):
+    def test_issue_465(self):
         json = self.m.as_dict().copy()
         json['creator'] = None
         m = Milestone(json)


### PR DESCRIPTION
This adds a check to Milestone for if the creator field is null before trying to create a User from it.

This also includes a regression test `test_issue_465` for the issue.

Fixes #465 