### PR TITLE
Add `tox` to dev-requirements and add .cache/ to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build/
 *.egg
 .env
 .ipynb_checkpoints
+.cache/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ pytest>=2.3.5
 wheel==0.21.0
 betamax>=0.5.0
 betamax_matchers>=0.2.0
+tox>=2.2.0


### PR DESCRIPTION
Tox appears to be necessary in order to run `make tests`, and wasn't previously installed as a dependency.

`.cache/` was added to gitignore as that directory appeared after running the following:

    make test-deps
    make tests