### PR TITLE
Add ability to list user email addresses

### DIFF
--- a/github3/users.py
+++ b/github3/users.py
@@ -102,6 +102,27 @@ class Plan(GitHubObject):
         return self.name == 'free'  # (No coverage)
 
 
+class UserEmail(GitHubCore):
+
+    """The :class:`UserEmail` object. Please see GitHub's `Emails documentation
+    <https://developer.github.com/v3/users/emails/>` for more information.
+    """
+
+    def _update_attributes(self, email):
+        #: Email address
+        self.email = email.get('email')
+        #: Whether the address has been verified
+        self.verified = email.get('verified')
+        #: Whether the address is the primary address
+        self.primary = email.get('primary')
+
+    def _repr(self):
+        return '<UserEmail [{0}]>'.format(self.email)
+
+    def __str__(self):
+        return self.email
+
+
 class User(BaseAccount):
 
     """The :class:`User <User>` object. This handles and structures information
@@ -236,6 +257,18 @@ class User(BaseAccount):
         url = self._build_url('user', 'emails')
         return self._boolean(self._delete(url, data=dumps(addresses)),
                              204, 404)
+
+    @requires_auth
+    def email_addresses(self, number=-1):
+        """Iterate over each email address in the authenticated
+        user's account.
+
+        :param int number: (optional), number of email addresses to return.
+            Default: -1, returns all of them
+        :returns: generator of :class:`UserEmail <github3.users.UserEmail>`
+        """
+        url = self._build_url('user', 'emails')
+        return self._iter(int(number), url, UserEmail)
 
     def is_assignee_on(self, username, repository):
         """Check if this user can be assigned to issues on username/repository.

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -9,6 +9,17 @@ class TestUser(IntegrationHelper):
 
     """Integration tests for methods on the User class."""
 
+    def test_email_addresses(self):
+        """Test the ability to retrieve the email addresses of the
+        authenticated user."""
+        self.token_login()
+        cassette_name = self.cassette_name('email_addresses')
+        with self.recorder.use_cassette(cassette_name):
+            user = self.gh.me()
+            assert user is not None
+            for address in user.email_addresses():
+                assert isinstance(address, github3.users.UserEmail)
+
     def test_events(self):
         """Show that a user can retrieve a events performed by a user."""
         cassette_name = self.cassette_name('events')

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -74,6 +74,20 @@ class TestPlan(BaseCase):
         assert self.plan.is_free()
 
 
+class TestUserEmail(BaseCase):
+    def __init__(self, methodName='runTest'):
+        super(TestUserEmail, self).__init__(methodName)
+        self.useremail = github3.users.UserEmail({
+            'email': 'test@email.com',
+            'verified': True,
+            'primary': True,
+        })
+
+    def test_str(self):
+        assert str(self.useremail) == self.useremail.email
+        assert repr(self.useremail) == '<UserEmail [test@email.com]>'
+
+
 class TestUser(BaseCase):
     def __init__(self, methodName='runTest'):
         super(TestUser, self).__init__(methodName)


### PR DESCRIPTION
This patch adds a new method to `User` to iterate over the email addresses associated with a user account.

@sigmavirus24 I've tried adding some tests but I'm clearly missing something as I can't get them to work. I played around a lot with Betamax to create a cassette for the integration test and the best I can get to is an `AuthenticationFailed: 401 Bad credentials` back from `models.py`. Any pointers you can give me to get this working correctly would be great—in the meantime I've included the test but no cassette, so currently this will break the tests. The functionality itself does seem to work, from some casual testing.