### PR TITLE
Add __getattr__ to GitHubObject class

### DIFF
--- a/github3/models.py
+++ b/github3/models.py
@@ -39,6 +39,14 @@ class GitHubObject(object):
     def _update_attributes(self, json):
         pass
 
+    def __getattr__(self, attribute):
+        """Proxy access to stored JSON."""
+        if attribute not in self._json_data:
+            raise AttributeError(attribute)
+        value = self._json_data.get(attribute, None)
+        setattr(self, attribute, value)
+        return value
+
     def as_dict(self):
         """Return the attributes for this object as a dictionary.
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,41 @@
+import github3
+import pytest
+import mock
+from .helper import create_example_data_helper
+
+get_user_key_example_data = create_example_data_helper('user_key_example')
+
+
+class TestGitHubObject:
+    """Test methods on GitHubObject class."""
+
+    def test_getattr(self):
+        """Test access to JSON data if attribute is not explicitly set."""
+
+        key = github3.users.Key(get_user_key_example_data())
+        # verified attribute is not set in _update_attributes for Key class
+        with pytest.raises(KeyError):
+            key.__dict__['verified']
+
+        assert key.verified is True
+
+    def test_getattr_attribute_not_in_json(self):
+        """Test AttributeError is raised when attribute is not in JSON."""
+        key = github3.users.Key(get_user_key_example_data())
+        with pytest.raises(AttributeError):
+            key.fakeattribute
+
+    @mock.patch('github3.models.GitHubObject.__getattr__')
+    def test_getattr_called(self, mocked_getattr):
+        """Show that getattr is called if attribute does not exist."""
+        key = github3.users.Key(get_user_key_example_data())
+        key.fakeattribute
+
+        assert mocked_getattr.called is True
+
+    @mock.patch('github3.models.GitHubObject.__getattr__')
+    def test_getattr_not_called_on_base_class(self, mocked_getattr):
+        """Show getattr is not called if attribute exists on base class."""
+        key = github3.users.Key(get_user_key_example_data())
+        key._uniq
+        assert mocked_getattr.called is False

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -21,7 +21,6 @@ class TestGitHubObject(UnitHelper):
     example_data = {
         'fake_attr': 'foo',
         'another_fake_attr': 'bar'
-
     }
 
     def test_exposes_attributes(self):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,41 +1,34 @@
-import github3
 import pytest
-import mock
-from .helper import create_example_data_helper
 
-get_user_key_example_data = create_example_data_helper('user_key_example')
+from github3.models import GitHubObject
+from .helper import UnitHelper
 
 
-class TestGitHubObject:
+class MyGetAttrTestClass(GitHubObject):
+    """Subclass for testing getattr on GitHubObject."""
+
+    def __init__(self, example_data, session=None):
+        super(MyGetAttrTestClass, self).__init__(example_data)
+
+    def _update_attributes(self, json_data):
+        self.fake_attr = json_data.get('fake_attr')
+
+
+class TestGitHubObject(UnitHelper):
     """Test methods on GitHubObject class."""
 
-    def test_getattr(self):
-        """Test access to JSON data if attribute is not explicitly set."""
+    described_class = MyGetAttrTestClass
+    example_data = {
+        'fake_attr': 'foo',
+        'another_fake_attr': 'bar'
 
-        key = github3.users.Key(get_user_key_example_data())
-        # verified attribute is not set in _update_attributes for Key class
-        with pytest.raises(KeyError):
-            key.__dict__['verified']
+    }
 
-        assert key.verified is True
+    def test_exposes_attributes(self):
+        """Verify JSON attributes are exposed even if not explicitly set."""
+        assert self.instance.another_fake_attr == 'bar'
 
-    def test_getattr_attribute_not_in_json(self):
+    def test_missingattribute(self):
         """Test AttributeError is raised when attribute is not in JSON."""
-        key = github3.users.Key(get_user_key_example_data())
         with pytest.raises(AttributeError):
-            key.fakeattribute
-
-    @mock.patch('github3.models.GitHubObject.__getattr__')
-    def test_getattr_called(self, mocked_getattr):
-        """Show that getattr is called if attribute does not exist."""
-        key = github3.users.Key(get_user_key_example_data())
-        key.fakeattribute
-
-        assert mocked_getattr.called is True
-
-    @mock.patch('github3.models.GitHubObject.__getattr__')
-    def test_getattr_not_called_on_base_class(self, mocked_getattr):
-        """Show getattr is not called if attribute exists on base class."""
-        key = github3.users.Key(get_user_key_example_data())
-        key._uniq
-        assert mocked_getattr.called is False
+            self.instance.missingattribute


### PR DESCRIPTION
Implements https://github.com/sigmavirus24/github3.py/issues/336

`_update_attributes` in `github3.users.Key` does not set the attribute `verified`.  Without explicitly setting the attribute, we can access the json attribute with __getattr__ on the base class - `GitHubObject`

Unit tests have been added to verify that base class attributes are affected by the change. Another pull request will handle migrating existing test cases in tests/test_models