### PR TITLE
Add RequiresAuth Helper class

### DIFF
--- a/tests/unit/helper.py
+++ b/tests/unit/helper.py
@@ -202,3 +202,13 @@ class UnitIteratorHelper(UnitHelper):
         """Stop mocking _get_json."""
         super(UnitIteratorHelper, self).tearDown()
         self.get_json_mock.stop()
+
+
+class UnitRequiresAuthenticationHelper(UnitHelper):
+
+    """Helper for unit tests that demonstrate authentication is required."""
+
+    def after_setup(self):
+        """Disable authentication on the session."""
+        self.session.auth = None
+        self.session.has_auth.return_value = False

--- a/tests/unit/test_auths.py
+++ b/tests/unit/test_auths.py
@@ -2,17 +2,19 @@
 import github3
 import pytest
 
-from .helper import UnitHelper, create_url_helper, create_example_data_helper
+from . import helper
 
-url_for = create_url_helper('https://api.github.com/authorizations/1')
+url_for = helper.create_url_helper('https://api.github.com/authorizations/1')
 
 
-class TestAuthorization(UnitHelper):
+class TestAuthorization(helper.UnitHelper):
 
     """Authorization unit tests."""
 
     described_class = github3.auths.Authorization
-    get_auth_example_data = create_example_data_helper('authorization_example')
+    get_auth_example_data = helper.create_example_data_helper(
+        'authorization_example'
+    )
     example_data = get_auth_example_data()
 
     def test_add_scopes(self):
@@ -46,7 +48,7 @@ class TestAuthorization(UnitHelper):
         })
 
 
-class TestAuthorizationRequiresAuth(UnitHelper):
+class TestAuthorizationRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
     """Test methods that require authentication on Authorization."""
 

--- a/tests/unit/test_gists.py
+++ b/tests/unit/test_gists.py
@@ -2,20 +2,25 @@
 import pytest
 import github3
 
-from .helper import (create_example_data_helper, create_url_helper,
-                     UnitHelper, UnitIteratorHelper)
+from . import helper
 
-gist_example_data = create_example_data_helper('gist_example')
-gist_example_short_data = create_example_data_helper('gist_example_short')
-gist_history_example_data = create_example_data_helper('gist_history_example')
-gist_comment_example_data = create_example_data_helper('gist_comment_example')
+gist_example_data = helper.create_example_data_helper('gist_example')
+gist_example_short_data = helper.create_example_data_helper(
+    'gist_example_short'
+)
+gist_history_example_data = helper.create_example_data_helper(
+    'gist_history_example'
+)
+gist_comment_example_data = helper.create_example_data_helper(
+    'gist_comment_example'
+)
 
-url_for = create_url_helper(
+url_for = helper.create_url_helper(
     'https://api.github.com/gists/b4c7ac7be6e591d0d155'
 )
 
 
-class TestGist(UnitHelper):
+class TestGist(helper.UnitHelper):
 
     """Test regular Gist methods."""
 
@@ -95,16 +100,12 @@ class TestGist(UnitHelper):
         assert str(self.instance) == str(self.instance.id)
 
 
-class TestGistRequiresAuth(UnitHelper):
+class TestGistRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
     """Test Gist methods which require authentication."""
 
     described_class = github3.gists.Gist
     example_data = gist_example_data()
-
-    def after_setup(self):
-        """Disable authentication."""
-        self.session.has_auth.return_value = False
 
     def test_create_comment(self):
         """Show that a user needs to authenticate to create a comment."""
@@ -142,7 +143,7 @@ class TestGistRequiresAuth(UnitHelper):
             self.instance.unstar()
 
 
-class TestGistIterators(UnitIteratorHelper):
+class TestGistIterators(helper.UnitIteratorHelper):
 
     """Test Gist methods that return Iterators."""
 
@@ -190,7 +191,7 @@ class TestGistIterators(UnitIteratorHelper):
         )
 
 
-class TestGistHistory(UnitHelper):
+class TestGistHistory(helper.UnitHelper):
 
     """Test Gist History."""
 
@@ -207,7 +208,7 @@ class TestGistHistory(UnitHelper):
         assert self.instance != history
 
 
-class TestGistComment(UnitHelper):
+class TestGistComment(helper.UnitHelper):
 
     """Test Gist Comments."""
 
@@ -228,7 +229,7 @@ class TestGistComment(UnitHelper):
         assert repr(self.instance).startswith('<Gist Comment')
 
 
-class TestGistFile(UnitHelper):
+class TestGistFile(helper.UnitHelper):
 
     """Test Gist File."""
 
@@ -236,13 +237,11 @@ class TestGistFile(UnitHelper):
     example_data = gist_example_short_data()
 
     def test_no_original_content(self):
-        """Show that attribute original content is None"""
+        """Show that attribute original content is None."""
         assert self.instance.original_content is None
 
     def test_get_file_content_from_raw_url(self):
-        """Show that Get request is made to Gist raw_url when method content
-        is called.
-        """
+        """Verify the request made to retrieve a GistFile's content."""
         self.instance.content()
 
         self.session.get.assert_called_once_with(self.instance.raw_url)

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -3,7 +3,7 @@ import pytest
 from github3 import AuthenticationFailed, GitHubError
 from github3.github import GitHub
 
-from .helper import UnitHelper, UnitIteratorHelper
+from . import helper
 
 
 def url_for(path=''):
@@ -11,7 +11,7 @@ def url_for(path=''):
     return 'https://api.github.com/' + path.strip('/')
 
 
-class TestGitHub(UnitHelper):
+class TestGitHub(helper.UnitHelper):
     described_class = GitHub
     example_data = None
 
@@ -345,7 +345,7 @@ class TestGitHub(UnitHelper):
         self.session.get.assert_called_once_with(url_for('user/10'))
 
 
-class TestGitHubIterators(UnitIteratorHelper):
+class TestGitHubIterators(helper.UnitIteratorHelper):
     described_class = GitHub
     example_data = None
 
@@ -868,17 +868,13 @@ class TestGitHubIterators(UnitIteratorHelper):
         )
 
 
-class TestGitHubRequiresAuthentication(UnitHelper):
+class TestGitHubRequiresAuthentication(
+        helper.UnitRequiresAuthenticationHelper):
 
     """Test methods that require authentication."""
 
     described_class = GitHub
     example_data = None
-
-    def after_setup(self):
-        """Disable authentication on the session."""
-        self.session.auth = None
-        self.session.has_auth.return_value = False
 
     def test_add_email_addresses(self):
         """Verify a user must be authenticated to add email addresses."""
@@ -991,7 +987,7 @@ class TestGitHubRequiresAuthentication(UnitHelper):
             self.instance.user_issues()
 
 
-class TestGitHubAuthorizations(UnitHelper):
+class TestGitHubAuthorizations(helper.UnitHelper):
     described_class = GitHub
     example_data = None
 

--- a/tests/unit/test_issues_issue.py
+++ b/tests/unit/test_issues_issue.py
@@ -86,16 +86,12 @@ class TestIssueIterators(helper.UnitIteratorHelper):
         )
 
 
-class TestLabelRequiresAuth(helper.UnitHelper):
+class TestLabelRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
     """Test that ensure certain methods on Label class requires auth."""
 
     described_class = github3.issues.label.Label
     example_data = get_issue_label_example_data()
-
-    def after_setup(self):
-        """Disable authentication on sessions."""
-        self.session.has_auth.return_value = False
 
     def test_delete(self):
         """Test that deleting a label requires authentication."""

--- a/tests/unit/test_issues_milestone.py
+++ b/tests/unit/test_issues_milestone.py
@@ -3,24 +3,22 @@ import datetime
 import github3
 import pytest
 
-from .helper import (UnitIteratorHelper, UnitHelper, create_url_helper,
-                     create_example_data_helper)
+from . import helper
 
-get_milestone_example_data = create_example_data_helper('milestone_example')
+get_milestone_example_data = helper.create_example_data_helper(
+    'milestone_example'
+)
 example_data = get_milestone_example_data()
 
-url_for = create_url_helper("https://api.github.com/repos/octocat/Hello-World/"
-                            "milestones/1")
+url_for = helper.create_url_helper("https://api.github.com/repos/octocat/"
+                                   "Hello-World/milestones/1")
 
 
-class TestMilestoneRequiresAuth(UnitHelper):
+class TestMilestoneRequiresAuth(helper.UnitRequiresAuthenticationHelper):
     """Test Milestone methods that require authentication."""
 
     described_class = github3.issues.milestone.Milestone
     example_data = example_data
-
-    def after_setup(self):
-        self.session.has_auth.return_value = False
 
     def test_delete(self):
         """Test that deleting milestone requires authentication."""
@@ -39,7 +37,7 @@ class TestMilestoneRequiresAuth(UnitHelper):
             self.instance.update(**data)
 
 
-class TestMilestone(UnitHelper):
+class TestMilestone(helper.UnitHelper):
     """Test Milestone methods."""
 
     described_class = github3.issues.milestone.Milestone
@@ -98,7 +96,7 @@ class TestMilestone(UnitHelper):
         assert self.session.post.called is False
 
 
-class TestMilestoneIterator(UnitIteratorHelper):
+class TestMilestoneIterator(helper.UnitIteratorHelper):
 
     """Test Milestone methods that return iterators."""
 

--- a/tests/unit/test_orgs.py
+++ b/tests/unit/test_orgs.py
@@ -3,15 +3,14 @@ import pytest
 from github3 import GitHubError
 from github3.orgs import Organization
 
-from .helper import (UnitHelper, UnitIteratorHelper, create_url_helper,
-                     create_example_data_helper)
+from . import helper
 
-url_for = create_url_helper('https://api.github.com/orgs/github')
+url_for = helper.create_url_helper('https://api.github.com/orgs/github')
 
-get_org_example_data = create_example_data_helper('org_example')
+get_org_example_data = helper.create_example_data_helper('org_example')
 
 
-class TestOrganization(UnitHelper):
+class TestOrganization(helper.UnitHelper):
     described_class = Organization
     example_data = get_org_example_data()
 
@@ -154,13 +153,9 @@ class TestOrganization(UnitHelper):
         assert self.session.get.called is False
 
 
-class TestOrganizationRequiresAuth(UnitHelper):
+class TestOrganizationRequiresAuth(helper.UnitRequiresAuthenticationHelper):
     described_class = Organization
     example_data = get_org_example_data()
-
-    def after_setup(self):
-        """Set MockedSession#has_auth.return_value to False."""
-        self.session.has_auth.return_value = False
 
     def test_add_member(self):
         """Show that one must be authenticated to add a member to an org."""
@@ -213,7 +208,7 @@ class TestOrganizationRequiresAuth(UnitHelper):
             self.instance.team(10)
 
 
-class TestOrganizationIterator(UnitIteratorHelper):
+class TestOrganizationIterator(helper.UnitIteratorHelper):
     described_class = Organization
 
     example_data = {

--- a/tests/unit/test_orgs_team.py
+++ b/tests/unit/test_orgs_team.py
@@ -3,15 +3,14 @@ import pytest
 from github3 import GitHubError
 from github3.orgs import Team
 
-from .helper import (UnitHelper, UnitIteratorHelper, create_url_helper,
-                     create_example_data_helper)
+from . import helper
 
-url_for = create_url_helper('https://api.github.com/teams/10')
+url_for = helper.create_url_helper('https://api.github.com/teams/10')
 
-get_team_example_data = create_example_data_helper('orgs_team_example')
+get_team_example_data = helper.create_example_data_helper('orgs_team_example')
 
 
-class TestTeam(UnitHelper):
+class TestTeam(helper.UnitHelper):
     described_class = Team
     example_data = get_team_example_data()
 
@@ -67,13 +66,9 @@ class TestTeam(UnitHelper):
         self.session.delete.assert_called_once_with(url_for('/repos/repo'))
 
 
-class TestTeamRequiresAuth(UnitHelper):
+class TestTeamRequiresAuth(helper.UnitRequiresAuthenticationHelper):
     described_class = Team
     example_data = get_team_example_data()
-
-    def after_setup(self):
-        """Set up for test cases in TestTeamRequiresAuth."""
-        self.session.has_auth.return_value = False
 
     def test_add_member_requires_auth(self):
         """Show that adding a repo to a team requires authentication."""
@@ -116,7 +111,7 @@ class TestTeamRequiresAuth(UnitHelper):
             self.instance.remove_repository('repo')
 
 
-class TestTeamIterator(UnitIteratorHelper):
+class TestTeamIterator(helper.UnitIteratorHelper):
     described_class = Team
 
     example_data = {

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -1,21 +1,22 @@
 """Unit tests for the github3.pulls module."""
 import pytest
 
-from .helper import (UnitHelper, UnitIteratorHelper, create_url_helper,
-                     create_example_data_helper)
+from . import helper
 
 from github3 import GitHubError
 from github3 import pulls
 
-get_pr_example_data = create_example_data_helper('pull_request_example')
+get_pr_example_data = helper.create_example_data_helper(
+    'pull_request_example'
+)
 
 
-url_for = create_url_helper(
+url_for = helper.create_url_helper(
     'https://api.github.com/repos/octocat/Hello-World/pulls/1'
 )
 
 
-class TestPullRequest(UnitHelper):
+class TestPullRequest(helper.UnitHelper):
     """PullRequest unit tests."""
 
     described_class = pulls.PullRequest
@@ -135,15 +136,12 @@ class TestPullRequest(UnitHelper):
         )
 
 
-class TestPullRequestRequiresAuthentication(UnitHelper):
+class TestPullRequestRequiresAuthentication(
+        helper.UnitRequiresAuthenticationHelper):
     """PullRequest unit tests that demonstrate which methods require auth."""
 
     described_class = pulls.PullRequest
     example_data = get_pr_example_data()
-
-    def after_setup(self):
-        """Make it appear as if the user has not authenticated."""
-        self.session.has_auth.return_value = False
 
     def test_close(self):
         """Show that you must be authenticated to close a Pull Request."""
@@ -171,7 +169,7 @@ class TestPullRequestRequiresAuthentication(UnitHelper):
             self.instance.update('foo', 'bar', 'bogus')
 
 
-class TestPullRequestIterator(UnitIteratorHelper):
+class TestPullRequestIterator(helper.UnitIteratorHelper):
     """Test PullRequest methods that return Iterators."""
 
     described_class = pulls.PullRequest
@@ -222,11 +220,11 @@ class TestPullRequestIterator(UnitIteratorHelper):
         )
 
 
-class TestReviewComment(UnitHelper):
+class TestReviewComment(helper.UnitHelper):
     """Unit tests for the ReviewComment class."""
 
     described_class = pulls.ReviewComment
-    get_comment_example_data = create_example_data_helper(
+    get_comment_example_data = helper.create_example_data_helper(
         'review_comment_example'
     )
     example_data = get_comment_example_data()
@@ -248,11 +246,11 @@ class TestReviewComment(UnitHelper):
             self.instance.reply('')
 
 
-class TestPullFile(UnitHelper):
+class TestPullFile(helper.UnitHelper):
     """Unit tests for the PullFile class."""
 
     described_class = pulls.PullFile
-    get_pull_file_example_data = create_example_data_helper(
+    get_pull_file_example_data = helper.create_example_data_helper(
         'pull_file_example'
     )
     example_data = get_pull_file_example_data()

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -6,18 +6,19 @@ from github3 import GitHubError
 from github3.null import NullObject
 from github3.repos.repo import Repository
 
-from .helper import (UnitHelper, UnitIteratorHelper, create_url_helper,
-                     create_example_data_helper)
+from . import helper
 
-url_for = create_url_helper(
+url_for = helper.create_url_helper(
     'https://api.github.com/repos/octocat/Hello-World'
 )
 
-get_repo_example_data = create_example_data_helper('repos_repo_example')
+get_repo_example_data = helper.create_example_data_helper(
+    'repos_repo_example'
+)
 repo_example_data = get_repo_example_data()
 
 
-class TestRepository(UnitHelper):
+class TestRepository(helper.UnitHelper):
 
     """Unit test for regular Repository methods."""
 
@@ -356,7 +357,7 @@ class TestRepository(UnitHelper):
         )
 
 
-class TestRepositoryIterator(UnitIteratorHelper):
+class TestRepositoryIterator(helper.UnitIteratorHelper):
 
     """Unit tests for Repository methods that return iterators."""
 
@@ -769,16 +770,12 @@ class TestRepositoryIterator(UnitIteratorHelper):
         )
 
 
-class TestRepositoryRequiresAuth(UnitHelper):
+class TestRepositoryRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
     """Unit test for regular Repository methods."""
 
     described_class = Repository
     example_data = repo_example_data
-
-    def after_setup(self):
-        """Set-up the session to not be authenticated."""
-        self.session.has_auth.return_value = False
 
     def test_add_collaborator(self):
         """Verify that adding a collaborator requires authentication."""

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -2,33 +2,30 @@ import pytest
 
 import github3
 
-from .helper import (UnitHelper, UnitIteratorHelper, create_url_helper,
-                     create_example_data_helper)
+from . import helper
 
-url_for = create_url_helper(
+url_for = helper.create_url_helper(
     'https://api.github.com/users/octocat'
 )
 
-key_url_for = create_url_helper(
+key_url_for = helper.create_url_helper(
     'https://api.github.com/user/keys'
 )
 
-get_users_example_data = create_example_data_helper('users_example')
-get_user_key_example_data = create_example_data_helper('user_key_example')
+get_users_example_data = helper.create_example_data_helper('users_example')
+get_user_key_example_data = helper.create_example_data_helper(
+    'user_key_example'
+)
 
 example_data = get_users_example_data()
 
 
-class TestUserKeyRequiresAuth(UnitHelper):
+class TestUserKeyRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
     """Test that ensure certain methods on Key class requires auth."""
 
     described_class = github3.users.Key
     example_data = get_user_key_example_data()
-
-    """Test Key methods that require authentication."""
-    def after_setup(self):
-        self.session.has_auth.return_value = False
 
     def test_update(self):
         """Test that updating a key requires authentication."""
@@ -41,7 +38,7 @@ class TestUserKeyRequiresAuth(UnitHelper):
             self.instance.delete()
 
 
-class TestUserKey(UnitHelper):
+class TestUserKey(helper.UnitHelper):
 
     """Test methods on Key class."""
 
@@ -79,7 +76,7 @@ class TestUserKey(UnitHelper):
         )
 
 
-class TestUserIterators(UnitIteratorHelper):
+class TestUserIterators(helper.UnitIteratorHelper):
 
     """Test User methods that return iterators."""
 
@@ -206,16 +203,12 @@ class TestUserIterators(UnitIteratorHelper):
         )
 
 
-class TestUsersRequiresAuth(UnitHelper):
+class TestUsersRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
     """Test that ensure certain methods on the User class requires auth."""
 
     described_class = github3.users.User
     example_data = example_data.copy()
-
-    def after_setup(self):
-        """Disable authentication on sessions."""
-        self.session.has_auth.return_value = False
 
     def test_organization_events(self):
         """Test that #organization_events requires authentication."""


### PR DESCRIPTION
Convert all unit test classes to use the UnitRequiresAuthHelper class
instead of having each define the after_setup method individually.