### PR TITLE
gh-543 Update regex to include hyphens in username

### DIFF
--- a/github3/github.py
+++ b/github3/github.py
@@ -998,7 +998,8 @@ class GitHub(GitHubCore):
         :returns: bool
         """
         from re import match
-        m = match('https?://[\w\d\-\.\:]+/\w+/[\w\._-]+/events/\w+', topic)
+        m = match('https?://[\w\d\-\.\:]+/\w[\w-]+\w/[\w\._-]+/events/\w+',
+                  topic)
         status = False
         if mode and topic and callback and m:
             data = [('hub.mode', mode), ('hub.topic', topic),

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -416,6 +416,32 @@ class TestGitHub(helper.UnitHelper):
             }
         )
 
+    def test_pubsubhubbub_invalid_username(self):
+        """Verify a valid call with invalid username does not call post."""
+        topic = (
+            'hub.topic',
+            'https://github.com/-octocat/hello-world/events/push'
+        )
+        body = [('hub.mode', 'subscribe'),
+                topic,
+                ('hub.callback', 'https://localhost/post')]
+        data = dict([(k[4:], v) for k, v in body])
+        self.instance.pubsubhubbub(**data)
+        assert self.session.post.called is False
+
+    def test_pubsubhubbub_valid_username(self):
+        """Verify a valid call with valid username calls post."""
+        topic = (
+            'hub.topic',
+            'https://github.com/o-cto-ca-t/hello-world/events/push'
+        )
+        body = [('hub.mode', 'subscribe'),
+                topic,
+                ('hub.callback', 'https://localhost/post')]
+        data = dict([(k[4:], v) for k, v in body])
+        self.instance.pubsubhubbub(**data)
+        assert self.session.post.called is True
+
     def test_pubsubhubbub_secret(self):
         """Verify the request for creating a pubsubhubbub hook."""
         topic = (


### PR DESCRIPTION
Fix bug where a username which contains a hyphen cannot be used in the `GitHub.pubsubhubbub` method.