### PR TITLE
Stop supporting Pythons 2.6 and 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,8 @@ env:
 
 matrix:
   include:
-    - python: 2.6
-      env: TOXENV=py26 REQUESTS_VERSION="===2.0.1"
     - python: 2.7
       env: TOXENV=py27 REQUESTS_VERSION="===2.0.1"
-    - python: 3.2
-      env: TOXENV=py32 REQUESTS_VERSION="===2.0.1"
     - python: 3.3
       env: TOXENV=py33 REQUESTS_VERSION="===2.0.1"
     - python: 3.4
@@ -29,12 +25,8 @@ matrix:
       env: TOXENV=py35 REQUESTS_VERSION="===2.0.1"
     - python: pypy
       env: TOXENV=pypy REQUESTS_VERSION="===2.0.1"
-    - python: 2.6
-      env: TOXENV=py26 REQUESTS_VERSION=""
     - python: 2.7
       env: TOXENV=py27 REQUESTS_VERSION=""
-    - python: 3.2
-      env: TOXENV=py32 REQUESTS_VERSION=""
     - python: 3.3
       env: TOXENV=py33 REQUESTS_VERSION=""
     - python: 3.4

--- a/setup.py
+++ b/setup.py
@@ -80,12 +80,11 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy,{py27,py34}-flake8,docstrings
+envlist = py27,py33,py34,pypy,{py27,py34}-flake8,docstrings
 
 [testenv]
 pip_pre = False


### PR DESCRIPTION
pip and virtualenv no longer support 3.2 and 2.6 has been end-of-lifed for
several years now. Let's stop supporting these for 1.0.