### PR TITLE
Update github user documentation

### DIFF
--- a/docs/examples/github.rst
+++ b/docs/examples/github.rst
@@ -166,6 +166,6 @@ Note that you **can not** change your login name via the API.
 
 This is the same as::
 
-    me = g.user()
+    me = g.me() # or me = g.user(your_user_name)
     if me.update(new_name, blog, company, bio=bio):
         print('Profile updated.')


### PR DESCRIPTION
The Github object has been updated to use either `.me()` or `.user(username)` (9e8b01fc006115c61bcbb3bc32fd59a86bb67575). I've updated the documentation to reflect this.