### PR TITLE
Update objects to inherit from GitHubCore

### DIFF
--- a/github3/git.py
+++ b/github3/git.py
@@ -11,12 +11,12 @@ from __future__ import unicode_literals
 
 from json import dumps
 from base64 import b64decode
-from .models import GitHubObject, GitHubCore, BaseCommit
+from .models import GitHubCore, BaseCommit
 from .users import User
 from .decorators import requires_auth
 
 
-class Blob(GitHubObject):
+class Blob(GitHubCore):
 
     """The :class:`Blob <Blob>` object.
 
@@ -216,7 +216,7 @@ class Tree(GitData):
         return self._instance_or_null(Tree, json)
 
 
-class Hash(GitHubObject):
+class Hash(GitHubCore):
 
     """The :class:`Hash <Hash>` object.
 

--- a/github3/repos/pages.py
+++ b/github3/repos/pages.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from ..models import GitHubObject
+from ..models import GitHubCore
 
 
-class PagesInfo(GitHubObject):
+class PagesInfo(GitHubCore):
     def _update_attributes(self, info):
         self._api = info.get('url')
 
@@ -24,7 +24,7 @@ class PagesInfo(GitHubObject):
         return '<Pages Info [{0}]>'.format(info)
 
 
-class PagesBuild(GitHubObject):
+class PagesBuild(GitHubCore):
     def _update_attributes(self, build):
         self._api = build.get('url')
 

--- a/github3/repos/status.py
+++ b/github3/repos/status.py
@@ -8,11 +8,11 @@ This module contains the Status object for GitHub's commit status API
 """
 from __future__ import unicode_literals
 
-from ..models import GitHubObject
+from ..models import GitHubCore
 from ..users import User
 
 
-class Status(GitHubObject):
+class Status(GitHubCore):
     """The :class:`Status <Status>` object. This represents information from
     the Repo Status API.
 

--- a/github3/repos/tag.py
+++ b/github3/repos/tag.py
@@ -8,10 +8,10 @@ This module contains the RepoTag object for GitHub's tag API.
 """
 from __future__ import unicode_literals
 
-from ..models import GitHubObject
+from ..models import GitHubCore
 
 
-class RepoTag(GitHubObject):
+class RepoTag(GitHubCore):
     """The :class:`RepoTag <RepoTag>` object. This stores the information
     representing a tag that was created on a repository.
 

--- a/github3/structs.py
+++ b/github3/structs.py
@@ -80,7 +80,7 @@ class GitHubIterator(models.GitHubCore, collections.Iterator):
 
             # languages returns a single dict. We want the items.
             if isinstance(json, dict):
-                if issubclass(self.cls, models.GitHubObject):
+                if issubclass(self.cls, models.GitHubCore):
                     raise exceptions.UnprocessableResponseBody(
                         "GitHub's API returned a body that could not be"
                         " handled", json

--- a/github3/users.py
+++ b/github3/users.py
@@ -12,7 +12,7 @@ from json import dumps
 from github3.auths import Authorization
 from uritemplate import URITemplate
 from .events import Event
-from .models import GitHubObject, GitHubCore, BaseAccount
+from .models import GitHubCore, BaseAccount
 from .decorators import requires_auth
 
 
@@ -74,7 +74,7 @@ class Key(GitHubCore):
         return False
 
 
-class Plan(GitHubObject):
+class Plan(GitHubCore):
     """The :class:`Plan <Plan>` object. This makes interacting with the plan
     information about a user easier. Please see GitHub's `Authenticated User
     <http://developer.github.com/v3/users/#get-the-authenticated-user>`_


### PR DESCRIPTION
```bash
$ grep -r --exclude "*.pyc" "GitHubObject" github3/*
github3/models.py:class GitHubObject(object):
github3/models.py:    """The :class:`GitHubObject <GitHubObject>`
object. A basic class to be
github3/models.py:        super(GitHubObject, self).__init__()
github3/models.py:class GitHubCore(GitHubObject):
```