### PR TITLE
Update documentation to reflect .me() usage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Let's get information about a user::
 
     gh = login('sigmavirus24', password='<password>')
 
-    sigmavirus24 = gh.user()
+    sigmavirus24 = gh.me()
     # <User [sigmavirus24:Ian Cordasco]>
 
     print(sigmavirus24.name)


### PR DESCRIPTION
Updated documentation to use 'gh.me()' instead of 'gh.user()'. Some of the documentation has been updated but it is still using the old 'gh.user()' on http://github3py.readthedocs.org/en/master/