### PR TITLE
Add License preview header to repository, to get a repository's license

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -126,3 +126,5 @@ Contributors
 - Abhijeet Kasurde (@akasurde)
 
 - Matthew Krueger (@mlkrueger1987)
+
+- Dejan Svetec (@dsvetec)

--- a/github3/github.py
+++ b/github3/github.py
@@ -1135,7 +1135,8 @@ class GitHub(GitHubCore):
         json = None
         if owner and repository:
             url = self._build_url('repos', owner, repository)
-            json = self._json(self._get(url), 200)
+            json = self._json(self._get(url, headers=License.CUSTOM_HEADERS),
+                              200)
         return self._instance_or_null(Repository, json)
 
     def repository_with_id(self, number):

--- a/github3/licenses.py
+++ b/github3/licenses.py
@@ -19,6 +19,7 @@ class License(GitHubCore):
     }
 
     def _update_attributes(self, license):
+        self._api = license.get('url', '')
         self.name = license.get('name')
         self.permitted = license.get('permitted')
         self.category = license.get('category')

--- a/github3/models.py
+++ b/github3/models.py
@@ -262,7 +262,7 @@ class GitHubCore(object):
             as described in the `Conditional Requests`_ section of the docs
         :returns: self
         """
-        headers = {}
+        headers = getattr(self, 'CUSTOM_HEADERS', {})
         if conditional:
             if self.last_modified:
                 headers['If-Modified-Since'] = self.last_modified

--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -113,6 +113,12 @@ class Repository(GitHubCore):
         self.id = repo.get('id', 0)
         #: Language property.
         self.language = repo.get('language', '')
+
+        # License containing only key, name, url & featured
+        #: :class:`License <github3.licenses.License>` object representing the
+        #: repository license.
+        self.original_license = License(repo.get('license', {}), self)
+
         #: Mirror property.
         self.mirror_url = repo.get('mirror_url', '')
 

--- a/tests/integration/test_repos_repo.py
+++ b/tests/integration/test_repos_repo.py
@@ -826,6 +826,17 @@ class TestRepository(helper.IntegrationHelper):
         for notification in notifications:
             assert isinstance(notification, github3.notifications.Thread)
 
+    def test_original_license(self):
+        """
+        Test that a repository's license can be retrieved at repository load.
+        """
+        cassette_name = self.cassette_name('original_license')
+        with self.recorder.use_cassette(cassette_name):
+            repository = self.gh.repository('sigmavirus24', 'github3.py')
+            assert repository is not None
+            assert isinstance(repository.original_license,
+                              github3.licenses.License)
+
     def test_pull_request(self):
         """Test that a user can retrieve a pull request from a repo."""
         cassette_name = self.cassette_name('pull_request')

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -495,7 +495,10 @@ class TestGitHub(helper.UnitHelper):
         """Verify the GET request for a repository."""
         self.instance.repository('user', 'repo')
 
-        self.session.get.assert_called_once_with(url_for('repos/user/repo'))
+        self.session.get.assert_called_once_with(
+            url_for('repos/user/repo'),
+            headers={'Accept': 'application/vnd.github.drax-preview+json'}
+        )
 
     def test_repository_with_invalid_repo(self):
         """Verify there is no call made for invalid repo combos."""

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -141,6 +141,22 @@ class TestGitHubCore(helper.UnitHelper):
             headers=expected_headers,
         )
 
+    def test_refresh_custom_headers(self):
+        """Verify the request of refreshing an object."""
+        self.instance.CUSTOM_HEADERS = {
+            'Accept': 'application/vnd.github.drax-preview+json'
+        }
+        expected_headers = {
+            'Accept': 'application/vnd.github.drax-preview+json'
+        }
+
+        self.instance.refresh()
+
+        self.session.get.assert_called_once_with(
+            self.url,
+            headers=expected_headers,
+        )
+
     def test_refresh_last_modified(self):
         """Verify the request of refreshing an object."""
         expected_headers = {


### PR DESCRIPTION
Issue #591

I've added the `application/vnd.github.drax-preview+json` media type when loading a repository so it loads with license data. The license data is partial (params: key, name, url & featured), so I've made some changes to load the whole license with `license.refresh()`. Because we can now retrieve the license this way, I saw no need in a seperate method to load the repository license. Therefore I removed `repo.license()`.