### PR TITLE
Add retrieving of the combined status for a RepoCommit

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -128,3 +128,5 @@ Contributors
 - Matthew Krueger (@mlkrueger1987)
 
 - Dejan Svetec (@dsvetec)
+
+- Björn Kautler (@Vampire)

--- a/docs/repos.rst
+++ b/docs/repos.rst
@@ -21,6 +21,7 @@ This part of the documentation covers:
 - :class:`RepoCommit <github3.repos.commit.RepoCommit>`
 - :class:`Comparison <github3.repos.comparison.Comparison>`
 - :class:`Status <github3.repos.status.Status>`
+- :class:`CombinedStatus <github3.repos.status.CombinedStatus>`
 - :class:`ContributorStats <github3.repos.stats.ContributorStats>`
 
 None of these objects should be instantiated directly by the user (developer).
@@ -143,6 +144,13 @@ about `comments <http://developer.github.com/v3/repos/comments/>`_.
 .. module:: github3.repos.status
 
 .. autoclass:: github3.repos.status.Status
+    :members:
+
+---------
+
+.. module:: github3.repos.status
+
+.. autoclass:: github3.repos.status.CombinedStatus
     :members:
 
 ---------

--- a/example-notebooks/statuses-api.ipynb
+++ b/example-notebooks/statuses-api.ipynb
@@ -46,7 +46,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 5
+     "prompt_number": 1
     },
     {
      "cell_type": "markdown",
@@ -66,7 +66,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 7
+     "prompt_number": 2
     },
     {
      "cell_type": "markdown",
@@ -130,7 +130,113 @@
        ]
       }
      ],
-     "prompt_number": 8
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Listing Combined Status Associated with a Reference"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import github3\n",
+      "\n",
+      "\n",
+      "repository = github3.repository('sigmavirus24', 'github3.py')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "With a repository object, we can now retrieve the statuses from a number of different commit-like objects which we can retrieve using the repository's ``commit`` method."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "commit = repository.commit('9df71a9772d5f43e332c855a32d4689f28289989')\n",
+      "tag = repository.commit('0.9.3')\n",
+      "branch = repository.commit('stable/0.9')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Each of these bindings now hold a reference to a different ``RepoCommit`` object and each has a ``status`` method. We can retrieve the combined status about each reference and print them."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "for ref in (commit, tag, branch):\n",
+      "    print('Showing combined status for \"{0.sha}\" ({0.html_url})'.format(ref))\n",
+      "    combined_status = ref.status()\n",
+      "    print(\"    State: {0.state}; Total count: {0.total_count}\".format(combined_status))\n",
+      "    print(\"    Statuses:\")\n",
+      "    for status in combined_status.statuses:\n",
+      "        print(\"        State: {0.state}; Description: {0.description}; Context: {0.context}\".format(status))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "Showing combined status for \"9df71a9772d5f43e332c855a32d4689f28289989\" (https://github.com/sigmavirus24/github3.py/commit/9df71a9772d5f43e332c855a32d4689f28289989)\n",
+        "    State: success; Total count: 1"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "    Statuses:\n",
+        "        State: success; Description: The Travis CI build passed; Context: continuous-integration/travis-ci\n",
+        "Showing combined status for \"52a3f30e05cf434285e775979f01f1a8355049a7\" (https://github.com/sigmavirus24/github3.py/commit/52a3f30e05cf434285e775979f01f1a8355049a7)\n",
+        "    State: success; Total count: 1"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "    Statuses:\n",
+        "        State: success; Description: The Travis CI build passed; Context: continuous-integration/travis-ci\n",
+        "Showing combined status for \"c4c3fc3ea3b56152303a1a856d7d7fe220b9b8b4\" (https://github.com/sigmavirus24/github3.py/commit/c4c3fc3ea3b56152303a1a856d7d7fe220b9b8b4)\n",
+        "    State: failure; Total count: 1"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "    Statuses:\n",
+        "        State: failure; Description: The Travis CI build failed; Context: continuous-integration/travis-ci/push\n"
+       ]
+      }
+     ],
+     "prompt_number": 3
     },
     {
      "cell_type": "heading",

--- a/github3/repos/commit.py
+++ b/github3/repos/commit.py
@@ -89,6 +89,16 @@ class RepoCommit(models.BaseCommit):
                          headers={'Accept': 'application/vnd.github.patch'})
         return resp.content if self._boolean(resp, 200, 404) else b''
 
+    def status(self):
+        """Retrieve the combined status for this commit.
+
+        :returns: the combined status for this commit
+        :rtype: :class:`~github3.repos.status.Status`
+        """
+        url = self._build_url('status', base_url=self._api)
+        json = self._json(self._get(url), 200)
+        return self._instance_or_null(status.CombinedStatus, json)
+
     def statuses(self):
         """Retrieve the statuses for this commit.
 

--- a/github3/repos/status.py
+++ b/github3/repos/status.py
@@ -25,7 +25,8 @@ class Status(GitHubCore):
         #: datetime object representing the creation of the status object
         self.created_at = self._strptime(status.get('created_at'))
         #: :class:`User <github3.users.User>` who created the object
-        self.creator = User(status.get('creator'))
+        if status.get('creator'):
+            self.creator = User(status.get('creator'))
         #: Short description of the Status
         self.description = status.get('description')
         #: GitHub ID for the status object
@@ -39,3 +40,21 @@ class Status(GitHubCore):
 
     def _repr(self):
         return '<Status [{s.id}:{s.state}]>'.format(s=self)
+
+class CombinedStatus(GitHubCore):
+    """The :class:`CombinedStatus <CombinedStatus>` object. This represents combined
+    information from the Repo Status API.
+
+    See also: http://developer.github.com/v3/repos/statuses/
+    """
+    def _update_attributes(self, combined_status):
+        #: State of the combined status, e.g., 'success', 'pending', 'failure'
+        self.state = combined_status.get('state')
+        #: Total count of sub-statuses
+        self.total_count = combined_status.get('total_count')
+        #: List of :class:`Status <github3.repos.status.Status>`
+        #: objects.
+        self.statuses = [Status(status) for status in combined_status.get('statuses')]
+
+    def _repr(self):
+        return '<CombinedStatus [{s.state}:{s.total_count} sub-statuses]>'.format(s=self)


### PR DESCRIPTION
Retrieving of the combined status of a commit was missing from the API.
This adds it.
