### PR TITLE
Fix serialization on Event objects.

### DIFF
--- a/github3/events.py
+++ b/github3/events.py
@@ -8,6 +8,8 @@ This module contains the class(es) related to Events
 """
 from __future__ import unicode_literals
 
+import copy
+
 from .models import GitHubCore
 
 
@@ -30,6 +32,10 @@ class Event(GitHubCore):
     """
 
     def _update_attributes(self, event):
+        # If we don't copy this, then we end up altering _json_data which we do
+        # not want to do:
+        event = copy.deepcopy(event)
+
         from .users import User
         from .orgs import Organization
         #: :class:`User <github3.users.User>` object representing the actor.

--- a/tests/integration/test_orgs.py
+++ b/tests/integration/test_orgs.py
@@ -117,6 +117,7 @@ class TestOrganization(IntegrationHelper):
 
             for event in o.events():
                 assert isinstance(event, github3.events.Event)
+                assert isinstance(event.as_json(), str)
 
     def test_members(self):
         """Test the ability to retrieve an organization's members."""


### PR DESCRIPTION
Add `utils.CustomJSONEncoder` which recursively calls `as_json` for attributes
which cannot normally be serialized.
