### PR TITLE
Update JSON data in refresh()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -128,3 +128,5 @@ Contributors
 - Matthew Krueger (@mlkrueger1987)
 
 - Dejan Svetec (@dsvetec)
+
+- Billy Keyes (@bluekeyes)

--- a/github3/models.py
+++ b/github3/models.py
@@ -285,6 +285,7 @@ class GitHubCore(object):
         headers = headers or None
         json = self._json(self._get(self._api, headers=headers), 200)
         if json is not None:
+            self._json_data = json
             self._update_attributes(json)
         return self
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,4 +1,5 @@
 import io
+import json
 import pytest
 import requests
 
@@ -183,6 +184,21 @@ class TestGitHubCore(helper.UnitHelper):
             self.url,
             headers=expected_headers,
         )
+
+    def test_refresh_json(self):
+        """Verify refreshing an object updates stored json data."""
+        expected_data = {
+            'changed_files': 4
+        }
+        response = requests.Response()
+        response.status_code = 200
+        response.raw = io.BytesIO(json.dumps(expected_data).encode('utf8'))
+        self.session.get.return_value = response
+
+        self.instance.refresh()
+
+        assert 'changed_files' in self.instance.as_dict()
+        assert self.instance.changed_files == 4
 
     def test_strptime(self):
         """Verify that method converts ISO 8601 formatted string."""


### PR DESCRIPTION
Otherwise, only attributes handled in _update_attributes() are refreshed and new values from the response are not available.

I ran into this with pull requests, where calling `refresh()` did not add the `changed_files` attribute that was available when fetching the PR directly. I suspect the same problem exists with other models.