### PR TITLE
add tests/unit/json/* to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,5 +10,6 @@ prune *.pyc
 recursive-include docs *.rst *.py Makefile
 recursive-include tests *.py *.json
 recursive-include tests/json *
+recursive-include tests/unit/json *
 recursive-include images *.png
 prune docs/_build


### PR DESCRIPTION
Since bd2e9f48, the unit test JSON files were being accidentally excluded from the distribution.  This caused `python setup.py test` to fail.