### PR TITLE
Update a few broken links to Github docs

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -34,4 +34,4 @@ Having individual handlers as we have now which modify the payload to use our
 objects when available is more sensible.
 
 .. links
-.. _type: http://developer.github.com/v3/events/types
+.. _type: https://developer.github.com/v3/activity/events/types

--- a/github3/events.py
+++ b/github3/events.py
@@ -14,8 +14,9 @@ from .models import GitHubCore
 class Event(GitHubCore):
 
     """The :class:`Event <Event>` object. It structures and handles the data
-    returned by via the `Events <https://developer.github.com/v3/activity/events>`_
-    section of the GitHub API.
+    returned by via the
+    `Events <https://developer.github.com/v3/activity/events>`_ section
+    of the GitHub API.
 
     Two events can be compared like so::
 

--- a/github3/events.py
+++ b/github3/events.py
@@ -14,7 +14,7 @@ from .models import GitHubCore
 class Event(GitHubCore):
 
     """The :class:`Event <Event>` object. It structures and handles the data
-    returned by via the `Events <http://developer.github.com/v3/events>`_
+    returned by via the `Events <https://developer.github.com/v3/activity/events>`_
     section of the GitHub API.
 
     Two events can be compared like so::
@@ -42,7 +42,7 @@ class Event(GitHubCore):
         self.org = None
         if event.get('org'):
             self.org = Organization(event.get('org'))
-        #: Event type http://developer.github.com/v3/activity/events/types/
+        #: Event type https://developer.github.com/v3/activity/events/types/
         self.type = event.get('type')
         handler = _payload_handlers.get(self.type, identity)
         #: Dictionary with the payload. Payload structure is defined by type_.


### PR DESCRIPTION
Github changed their URLs at some point. I can't guarantee this is
everything, but it should at least cover the URLs related to Events