### PR TITLE
Create the StarredRepository object

### DIFF
--- a/docs/repos.rst
+++ b/docs/repos.rst
@@ -6,6 +6,7 @@ Repository
 This part of the documentation covers:
 
 - :class:`Repository <github3.repos.repo.Repository>`
+- :class:`StarredRepository <github3.repos.repo.StarredRepository>`
 - :class:`Asset <github3.repos.release.Asset>`
 - :class:`Branch <github3.repos.branch.Branch>`
 - :class:`Contents <github3.repos.contents.Contents>`
@@ -41,6 +42,11 @@ Repository Objects
 .. module:: github3.repos.repo
 
 .. autoclass:: github3.repos.repo.Repository
+    :inherited-members:
+
+---------
+
+.. autoclass:: github3.repos.repo.StarredRepository
     :inherited-members:
 
 ---------

--- a/github3/repos/__init__.py
+++ b/github3/repos/__init__.py
@@ -8,5 +8,6 @@ See also: http://developer.github.com/v3/repos/
 """
 
 from .repo import Repository
+from .repo import StarredRepository
 
-__all__ = [Repository]
+__all__ = ('Repository', 'StarredRepository')

--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -1984,6 +1984,27 @@ class Repository(GitHubCore):
         return json
 
 
+class StarredRepository(GitHubCore):
+
+    """The :class:`~github3.repos.repo.StarredRepository` object.
+
+    It represents how GitHub sends back a repository a user has starred, e.g.,
+    from :meth:`~github3.users.User.starred_repositories`.
+
+    See also:
+    https://developer.github.com/v3/activity/starring/#list-repositories-being-starred
+
+    """
+
+    def _update_attributes(self, starred_repository):
+        self.starred_at = self._strptime(starred_repository.get('starred_at'))
+        self.repository = Repository(starred_repository.get('repo'), self)
+        self.repo = self.repository
+
+    def _repr(self):
+        return '<StarredRepository [{0!r}]>'.format(self.repository)
+
+
 def repo_issue_params(milestone=None,
                       state=None,
                       assignee=None,

--- a/github3/users.py
+++ b/github3/users.py
@@ -360,14 +360,14 @@ class User(BaseAccount):
             'desc'
         :param str etag: (optional), ETag from a previous request to the same
             endpoint
-        :returns: generator of :class:`Repository <github3.repos.Repository>`
+        :returns: generator of :class:`~github3.repos.repo.StarredRepository`
         """
-        from .repos import Repository
+        from .repos import Repository, StarredRepository
 
         params = {'sort': sort, 'direction': direction}
         self._remove_none(params)
         url = self.starred_urlt.expand(owner=None, repo=None)
-        return self._iter(int(number), url, Repository, params, etag,
+        return self._iter(int(number), url, StarredRepository, params, etag,
                           headers=Repository.STAR_HEADERS)
 
     def subscriptions(self, number=-1, etag=None):

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -140,7 +140,7 @@ class TestUser(IntegrationHelper):
 
         assert len(repos) > 0
         for starred in repos:
-            assert isinstance(starred, github3.repos.Repository)
+            assert isinstance(starred, github3.repos.StarredRepository)
             assert isinstance(starred.starred_at, datetime.datetime)
 
     def test_subscriptions(self):


### PR DESCRIPTION
GitHub silently changed their /users/:username/starred endpoint to
return an object with a different structure. This made the Repository
objects returned by User#starred_repositories useless.

The StarredRepository properly represents the structure of the data
that they return and makes things sensible again.

Closes gh-619