### PR TITLE
Raise exception for instance_or_null

### DIFF
--- a/github3/models.py
+++ b/github3/models.py
@@ -143,7 +143,7 @@ class GitHubCore(object):
         if json is None:
             return NullObject(instance_class.__name__)
         if not isinstance(json, dict):
-            return exceptions.UnprocessableResponseBody(
+            raise exceptions.UnprocessableResponseBody(
                 "GitHub's API returned a body that could not be handled", json
             )
         try:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -107,6 +107,11 @@ class TestGitHubCore(helper.UnitHelper):
         github_core = GitHubCore.from_json('{}')
         assert isinstance(github_core, GitHubCore)
 
+    def test_instance_or_null(self):
+        """Verify method raises exception when json is not a dict."""
+        with pytest.raises(exceptions.UnprocessableResponseBody):
+            self.instance._instance_or_null(GitHubCore, [])
+
     def test_json(self):
         """Verify JSON information is retrieved correctly."""
         response = requests.Response()


### PR DESCRIPTION
When the wrong data type is passed to the method, like a list or string,
an exception is returned.  Instead, we should be raising the exception.

I added a single unit test, which asserts that an error is raised.

Fixes https://github.com/sigmavirus24/github3.py/issues/628 and
https://github.com/sigmavirus24/github3.py/issues/627.