### PR TITLE
Convert remaining uritemplate.py references

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -132,3 +132,5 @@ Contributors
 - Billy Keyes (@bluekeyes)
 
 - Evan Borgstrom (@borgstrom)
+
+- Jordan Moldow (@jmoldow)

--- a/README.rst
+++ b/README.rst
@@ -17,10 +17,10 @@ Dependencies
 ------------
 
 - requests_  by Kenneth Reitz
-- uritemplate.py_ by Ian Cordasco
+- uritemplate_ by Ian Cordasco
 
 .. _requests: https://github.com/kennethreitz/requests
-.. _uritemplate.py: https://github.com/sigmavirus24/uritemplate
+.. _uritemplate: https://github.com/sigmavirus24/uritemplate
 
 Contributing
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,10 +111,10 @@ Dependencies
 ~~~~~~~~~~~~
 
 - requests_ by Kenneth Reitz
-- uritemplate.py_ by Ian Cordasco
+- uritemplate_ by Ian Cordasco
 
 .. _requests: https://github.com/kennethreitz/requests
-.. _uritemplate.py: https://github.com/sigmavirus24/uritemplate
+.. _uritemplate: https://github.com/sigmavirus24/uritemplate
 
 
 Contributing

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 [metadata]
 requires-dist=
     requests>=2.0
-    uritemplate.py>=0.2.0
+    uritemplate>=3.0.0
     pyOpenSSL>=0.13; python_version<="2.7"
     ndg-httpsclient; python_version<="2.7"
     pyasn1; python_version<="2.7"


### PR DESCRIPTION
In particular, fix setup.cfg to match setup.py, so that wheel
installs will grab the correct PyPI package.