### PR TITLE
Allow authorize() to be given a GitHub object

### DIFF
--- a/github3/api.py
+++ b/github3/api.py
@@ -14,7 +14,7 @@ gh = GitHub()
 
 
 def authorize(username, password, scopes, note='', note_url='', client_id='',
-              client_secret='', two_factor_callback=None):
+              client_secret='', two_factor_callback=None, github=None):
     """Obtain an authorization token for the GitHub API.
 
     :param str username: (required)
@@ -29,10 +29,12 @@ def authorize(username, password, scopes, note='', note_url='', client_id='',
         which to create the token
     :param func two_factor_callback: (optional), function to call when a
         Two-Factor Authentication code needs to be provided by the user.
+    :param GitHub github: (optional), GitHub (or GitHubEnterprise) object for
+        login.
     :returns: :class:`Authorization <Authorization>`
 
     """
-    gh = GitHub()
+    gh = github or GitHub()
     gh.login(two_factor_callback=two_factor_callback)
     return gh.authorize(username, password, scopes, note, note_url, client_id,
                         client_secret)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -46,6 +46,15 @@ class TestAPI(unittest.TestCase):
             github3.authorize(*args)
             gh().authorize.assert_called_once_with(*args)
 
+    def test_authorize_with_github_argument(self):
+        """Show that github3.authorize can use an existing GitHub object."""
+        args = ('login',  'password', ['scope'], 'note', 'url.com', '', '')
+        github = mock.Mock(spec_set=github3.GitHub)
+        with mock.patch('github3.api.GitHub') as gh:
+            github3.authorize(*args, github=github)
+            gh().assert_not_called()
+            github.authorize.assert_called_once_with(*args)
+
     def test_create_gist(self):
         """Show that github3.create_gist proxies to GitHub."""
         args = ('description', {'files': ['file']})


### PR DESCRIPTION
In particular, this makes it much easier to do two factor login
with a GitHubEnterprise instance.
