### PR TITLE
GitHub User Administration: as per API use 'login' not 'id' for impersonate, revoke_impersonation, rename, delete

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -132,3 +132,5 @@ Contributors
 - Billy Keyes (@bluekeyes)
 
 - Evan Borgstrom (@borgstrom)
+
+- Goodwillcoding (@goodwillcoding)

--- a/github3/users.py
+++ b/github3/users.py
@@ -391,7 +391,7 @@ class User(BaseAccount):
         :param str login: (required), new name of the user
         :returns: bool
         """
-        url = self._build_url('admin', 'users', self.id)
+        url = self._build_url('admin', 'users', self.login)
         payload = {'login': login}
         resp = self._boolean(self._patch(url, data=payload), 202, 403)
         return resp
@@ -407,7 +407,7 @@ class User(BaseAccount):
             i.e., 'gist', 'user'
         :returns: :class:`Authorization <Authorization>`
         """
-        url = self._build_url('admin', 'users', self.id, 'authorizations')
+        url = self._build_url('admin', 'users', self.login, 'authorizations')
         data = {}
 
         if scopes:
@@ -425,7 +425,7 @@ class User(BaseAccount):
 
         :returns: bool -- True if successful, False otherwise
         """
-        url = self._build_url('admin', 'users', self.id, 'authorizations')
+        url = self._build_url('admin', 'users', self.login, 'authorizations')
 
         return self._boolean(self._delete(url), 204, 403)
 
@@ -494,5 +494,5 @@ class User(BaseAccount):
 
         :returns: bool -- True if successful, False otherwise
         """
-        url = self._build_url('admin', 'users', self.id)
+        url = self._build_url('admin', 'users', self.login)
         return self._boolean(self._delete(url), 204, 403)

--- a/tests/unit/test_github_enterprise.py
+++ b/tests/unit/test_github_enterprise.py
@@ -52,7 +52,7 @@ class TestUserAdministration(UnitHelper):
         return self.base_url + 'users/' + example_data['login'] + path
 
     def url_for_admin(self, path=''):
-        return self.base_url + 'admin/users/' + str(example_data['id']) + path
+        return self.base_url + 'admin/users/' + str(example_data['login']) + path
 
     def test_delete_user(self):
         """Show that an admin can ask for user deletion."""


### PR DESCRIPTION
The Github enterprise API takes username (a.k.a login) not user id for all the methods above.
