### PR TITLE
GitHub Enterprise : Fix admin functions for users incorrectly using id instead of login 

### DIFF
--- a/github3/users.py
+++ b/github3/users.py
@@ -391,7 +391,7 @@ class User(BaseAccount):
         :param str login: (required), new name of the user
         :returns: bool
         """
-        url = self._build_url('admin', 'users', self.id)
+        url = self._build_url('admin', 'users', self.login)
         payload = {'login': login}
         resp = self._boolean(self._patch(url, data=payload), 202, 403)
         return resp
@@ -407,7 +407,7 @@ class User(BaseAccount):
             i.e., 'gist', 'user'
         :returns: :class:`Authorization <Authorization>`
         """
-        url = self._build_url('admin', 'users', self.id, 'authorizations')
+        url = self._build_url('admin', 'users', self.login, 'authorizations')
         data = {}
 
         if scopes:
@@ -425,7 +425,7 @@ class User(BaseAccount):
 
         :returns: bool -- True if successful, False otherwise
         """
-        url = self._build_url('admin', 'users', self.id, 'authorizations')
+        url = self._build_url('admin', 'users', self.login, 'authorizations')
 
         return self._boolean(self._delete(url), 204, 403)
 
@@ -494,5 +494,5 @@ class User(BaseAccount):
 
         :returns: bool -- True if successful, False otherwise
         """
-        url = self._build_url('admin', 'users', self.id)
+        url = self._build_url('admin', 'users', self.login)
         return self._boolean(self._delete(url), 204, 403)

--- a/tests/unit/test_github_enterprise.py
+++ b/tests/unit/test_github_enterprise.py
@@ -1,6 +1,5 @@
-from github3.github import GitHubEnterprise
 import github3
-
+from github3.github import GitHubEnterprise
 from .helper import UnitHelper, create_example_data_helper
 
 get_example_user = create_example_data_helper('user_example')
@@ -52,7 +51,8 @@ class TestUserAdministration(UnitHelper):
         return self.base_url + 'users/' + example_data['login'] + path
 
     def url_for_admin(self, path=''):
-        return self.base_url + 'admin/users/' + str(example_data['id']) + path
+        return self.base_url + 'admin/users/' + str(example_data['login']) \
+               + path
 
     def test_delete_user(self):
         """Show that an admin can ask for user deletion."""


### PR DESCRIPTION
This pull request fixes an issue with the admin API for GitHub Enterprise, where some functions targeting users where using user id instead of login.