### PR TITLE
adding team slug

### DIFF
--- a/github3/orgs.py
+++ b/github3/orgs.py
@@ -44,6 +44,8 @@ class Team(GitHubCore):
         self._api = team.get('url', '')
         #: This team's name.
         self.name = team.get('name')
+        #: This team's slug.
+        self.slug = team.get('slug')
         #: Unique ID of the team.
         self.id = team.get('id')
         #: Permission level of the group.


### PR DESCRIPTION
Addressing https://github.com/sigmavirus24/github3.py/issues/653 as part of https://24pullrequests.com

Quite a simple change to add in the slug, I had a look around and the slug is already included as part of the `team.json` file and I couldn't find tests asserting the other attributes.

On another note, this repo had the highest contribution score I could find on https://24pullrequests.com, congrats :tada: 