### PR TITLE
Support reading tagger as User.

### DIFF
--- a/LATEST_VERSION_NOTES.rst
+++ b/LATEST_VERSION_NOTES.rst
@@ -6,6 +6,7 @@ Unreleased
 - Add ``Organization#all_events``.
 - Deprecate ``Organization#events`` in favor of ``Organization#public_events``.
 - Fix test failtures on windows caused by unclosed file handles.
+- Add ``Tag.tagger_as_User`` which attempts to return the tagger as as User.
 
 1.0.0a4: 2016-02-19
 ~~~~~~~~~~~~~~~~~~~

--- a/github3/git.py
+++ b/github3/git.py
@@ -195,6 +195,14 @@ class Tag(GitData):
     def _repr(self):
         return '<Tag [{0}]>'.format(self.tag)
 
+    def tagger_as_User(self):
+        """Attempt to return the tagger attribute as a
+        :class:`User <github3.users.User>`. No guarantees are made about the
+        validity of this object, i.e., having a login or created_at object.
+
+        """
+        return User(self.tagger, self)
+
 
 class Tree(GitData):
 

--- a/tests/unit/json/git_tag_example
+++ b/tests/unit/json/git_tag_example
@@ -1,0 +1,16 @@
+{
+  "tag": "v0.0.1",
+  "sha": "940bd336248efae0f9ee5bc7b2d5c985887b16ac",
+  "url": "https://api.github.com/repos/octocat/Hello-World/git/tags/940bd336248efae0f9ee5bc7b2d5c985887b16ac",
+  "message": "initial version\n",
+  "tagger": {
+    "name": "Scott Chacon",
+    "email": "schacon@gmail.com",
+    "date": "2014-11-07T22:01:45Z"
+  },
+  "object": {
+    "type": "commit",
+    "sha": "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c"
+  }
+}

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -11,6 +11,7 @@ reference_url_for = create_url_helper('https://api.github.com/repos/'
                                       'git/refs/heads/featureA')
 
 get_commit_example_data = create_example_data_helper('commit_example')
+get_git_tag_example_data = create_example_data_helper('git_tag_example')
 get_reference_example_data = create_example_data_helper('reference_example')
 
 
@@ -63,6 +64,22 @@ class TestCommit(UnitHelper):
     def test_author_as_User(self):
         """Show that commit_as_Author() returns instance of User."""
         user = self.instance.author_as_User()
+        assert isinstance(user, github3.users.User)
+
+
+class TestGitTag(UnitHelper):
+
+    """Git Tag unit test."""
+
+    described_class = github3.git.Tag
+    example_data = get_git_tag_example_data()
+
+    def test_repr(self):
+        assert repr(self.instance).startswith('<Tag')
+
+    def test_tagger_as_User(self):
+        """Show that tagger_as_User() returns instance of User."""
+        user = self.instance.tagger_as_User()
         assert isinstance(user, github3.users.User)
 
 


### PR DESCRIPTION
Allow the tagger to be fetched as a User, same as `author_as_User` & `committer_as_User` in `Commit`
