### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -69,10 +69,10 @@
 - Allow users to pass a two-factor authentication callback to 
   ``GitHub#authorize``.
 
-.. _single authorization: https://github3py.readthedocs.org/en/latest/github.html#github3.github.GitHub.revoke_authorization
-.. _all authorizations: https://github3py.readthedocs.org/en/latest/github.html#github3.github.GitHub.revoke_authorizations
-.. _ping: https://github3py.readthedocs.org/en/latest/repos.html?highlight=ping#github3.repos.hook.Hook.ping
-.. _Repository's collaborators: https://github3py.readthedocs.org/en/latest/repos.html#github3.repos.repo.Repository.iter_collaborators
+.. _single authorization: https://github3py.readthedocs.io/en/latest/github.html#github3.github.GitHub.revoke_authorization
+.. _all authorizations: https://github3py.readthedocs.io/en/latest/github.html#github3.github.GitHub.revoke_authorizations
+.. _ping: https://github3py.readthedocs.io/en/latest/repos.html?highlight=ping#github3.repos.hook.Hook.ping
+.. _Repository's collaborators: https://github3py.readthedocs.io/en/latest/repos.html#github3.repos.repo.Repository.iter_collaborators
 .. _pagination changes: https://developer.github.com/changes/2014-03-18-paginating-method-changes/
 .. _stargarzers_url: https://github.com/sigmavirus24/github3.py/pull/240
 

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ this in a virtual enviroment. These need to be installed for the tests to run.
 
 .. _betamax: https://github.com/sigmavirus24/betamax
 .. _coverage: http://nedbatchelder.com/code/coverage/
-.. _mock: http://mock.readthedocs.org/en/latest/
+.. _mock: https://mock.readthedocs.io/en/latest/
 
 License
 -------
@@ -56,7 +56,7 @@ Examples
 
 See the docs_ for more examples.
 
-.. _docs: http://github3py.readthedocs.org/en/latest/index.html#more-examples
+.. _docs: https://github3py.readthedocs.io/en/latest/index.html#more-examples
 
 Testing
 ~~~~~~~

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -264,4 +264,4 @@ Betamax sanitizes information like that before saving the cassette. It never
 does hurt to double check though.
 
 .. _Betamax: https://github.com/sigmavirus24/betamax
-.. _cassettes: https://betamax.readthedocs.org/en/latest/cassettes.html
+.. _cassettes: https://betamax.readthedocs.io/en/latest/cassettes.html

--- a/github3/__about__.py
+++ b/github3/__about__.py
@@ -7,7 +7,7 @@ __license__ = 'Modified BSD'
 __copyright__ = 'Copyright 2012-2016 Ian Cordasco'
 __version__ = '1.0.0a4'
 __version_info__ = tuple(int(i) for i in __version__.split('.') if i.isdigit())
-__url__ = 'http://github3.readthedocs.org'
+__url__ = 'https://github3.readthedocs.io'
 
 __all__ = (
     '__package_name__', '__title__', '__author__', '__author_email__',

--- a/github3/__init__.py
+++ b/github3/__init__.py
@@ -3,7 +3,7 @@
 github3
 =======
 
-See http://github3.readthedocs.org/ for documentation.
+See https://github3.readthedocs.io/ for documentation.
 
 :copyright: (c) 2012-2016 by Ian Cordasco
 :license: Modified BSD, see LICENSE for more details

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     license='3-clause BSD',
     author="Ian Cordasco",
     author_email="graffatcolmingov@gmail.com",
-    url="https://github3py.readthedocs.org",
+    url="https://github3py.readthedocs.io",
     packages=packages,
     install_requires=requires,
     classifiers=[


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.