### PR TITLE
fix github.me() trace

### DIFF
--- a/github3/users.py
+++ b/github3/users.py
@@ -601,7 +601,7 @@ class AuthenticatedUser(User):
         self.total_private_repos = user.get('total_private_repos', 0)
 
         #: Which plan this user is on
-        self.plan = Plan(user.get('plan',{}))
+        self.plan = Plan(user.get('plan', {}))
 
         #: Number of repo contributions. Only appears in ``repo.contributors``
         contributions = user.get('contributions')

--- a/github3/users.py
+++ b/github3/users.py
@@ -592,16 +592,16 @@ class AuthenticatedUser(User):
 
     def _update_attributes(self, user):
         #: How much disk consumed by the user
-        self.disk_usage = user['disk_usage']
+        self.disk_usage = user.get('disk_usage', 0)
 
         #: Number of private repos owned by this user
-        self.owned_private_repos = user['owned_private_repos']
+        self.owned_private_repos = user.get('owned_private_repos', 0)
 
         #: Total number of private repos
-        self.total_private_repos = user['total_private_repos']
+        self.total_private_repos = user.get('total_private_repos', 0)
 
         #: Which plan this user is on
-        self.plan = Plan(user['plan'])
+        self.plan = Plan(user.get('plan',{}))
 
         #: Number of repo contributions. Only appears in ``repo.contributors``
         contributions = user.get('contributions')


### PR DESCRIPTION
@sigmavirus24 
Fix github.me() trace:
1. if token without user scope, can't get disk_usage, owned_private_repos, total_private_repos and plan
2. for enterprise single user, even I set token with user scope, I didn't get plan, I don't know why.

You can refer to [get-the-authenticated-user](https://developer.github.com/v3/users/#get-the-authenticated-user) for details