### PR TITLE
Switch class used when creating a user

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -150,3 +150,5 @@ Contributors
 - Jesse Keating (@omgjlk)
 
 - @rco-ableton
+
+- Mark Troyer (@discogestalt)

--- a/github3/github.py
+++ b/github3/github.py
@@ -1748,12 +1748,12 @@ class GitHubEnterprise(GitHub):
         :param str login: (required), The user's username.
         :param str email: (required), The user's email address.
 
-        :returns: :class:`User <github3.users.User>`, if successful
+        :returns: :class:`ShortUser <github3.users.ShortUser>`, if successful
         """
         url = self._build_url('admin', 'users')
         payload = {'login': login, 'email': email}
         json_data = self._json(self._post(url, data=payload), 201)
-        return self._instance_or_null(users.User, json_data)
+        return self._instance_or_null(users.ShortUser, json_data)
 
     @requires_auth
     def admin_stats(self, option):


### PR DESCRIPTION
create_user fails because the github3.users.User class expects data that is not present at the time of user creation. github3.users.ShortUser needs to be used instead.