### PR TITLE
Drop preview header from reviews API call

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -146,3 +146,5 @@ Contributors
 - Björn Kautler (@Vampire)
 
 - David Prothero (@dprothero)
+
+- Jesse Keating (@omgjlk)

--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -427,11 +427,8 @@ class PullRequest(models.GitHubCore):
             endpoint
         :returns: generator of :class:`PullReview <PullReview>`\ s
         """
-        # Accept the preview headers for reviews
-        headers = {'Accept': 'application/vnd.github.black-cat-preview+json'}
         url = self._build_url('reviews', base_url=self._api)
-        return self._iter(int(number), url, PullReview, etag=etag,
-                          headers=headers)
+        return self._iter(int(number), url, PullReview, etag=etag)
 
     @requires_auth
     def update(self, title=None, body=None, state=None):

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -243,7 +243,7 @@ class TestPullRequestIterator(helper.UnitIteratorHelper):
         self.session.get.assert_called_once_with(
             url_for('reviews'),
             params={'per_page': 100},
-            headers={'Accept': 'application/vnd.github.black-cat-preview+json'}
+            headers={}
         )
 
 


### PR DESCRIPTION
As of
https://developer.github.com/changes/2017-05-09-end-black-cat-preview/
the reviews endpoint is no longer preview, and is now an official part
of the API. It is no longer necessary to set a header when accessing
this endpoint.