### PR TITLE
Add merge_commit_sha attribute to PullRequest object

### DIFF
--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -185,6 +185,12 @@ class PullRequest(models.GitHubCore):
         #: Dictionary of _links. Changed in 1.0
         self.links = self._get_attribute(pull, '_links', {})
 
+        #: If unmerged, holds the sha of the commit to test mergability.
+        #: If merged, holds commit sha of the merge commit, squashed commit on
+        #: the base branch or the commit that the base branch was updated to
+        #: after rebasing the PR.
+        self.merge_commit_sha = self._get_attribute(pull, 'merge_commit_sha')
+
         #: Boolean representing whether the pull request has been merged
         self.merged = self._get_attribute(pull, 'merged')
 

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -144,6 +144,13 @@ class TestPullRequest(helper.UnitHelper):
             }
         )
 
+    def test_attributes(self):
+        """Show that we extract attributes correctly."""
+        assert self.instance.merge_commit_sha == \
+            'e5bd3914e2e596debea16f433f57875b5b90bcd6'
+        assert not self.instance.merged
+        assert self.instance.mergeable
+
 
 class TestPullRequestRequiresAuthentication(
         helper.UnitRequiresAuthenticationHelper):


### PR DESCRIPTION
This adds the `merge_commit_sha` attribute to the Pull Request object. More info about the attribute here: https://developer.github.com/v3/pulls/#get-a-single-pull-request

I could not find a test for attributes so added one.
