### PR TITLE
Fix flake8 issues and drop py33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27 REQUESTS_VERSION="===2.0.1"
-    - python: 3.3
-      env: TOXENV=py33 REQUESTS_VERSION="===2.0.1"
     - python: 3.4
       env: TOXENV=py34 REQUESTS_VERSION="===2.0.1"
     - python: 3.5
@@ -27,8 +25,6 @@ matrix:
       env: TOXENV=pypy REQUESTS_VERSION="===2.0.1"
     - python: 2.7
       env: TOXENV=py27 REQUESTS_VERSION=""
-    - python: 3.3
-      env: TOXENV=py33 REQUESTS_VERSION=""
     - python: 3.4
       env: TOXENV=py34 REQUESTS_VERSION=""
     - python: 3.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,6 @@ environment:
       TOXENV: py27
     - PYTHON: "C:\\Python27-x64"
       TOXENV: py27
-    - PYTHON: "C:\\Python33"
-      TOXENV: py33
-    - PYTHON: "C:\\Python33-x64"
-      TOXENV: py33
     - PYTHON: "C:\\Python34"
       TOXENV: py34
     - PYTHON: "C:\\Python34-x64"

--- a/github3/exceptions.py
+++ b/github3/exceptions.py
@@ -18,7 +18,7 @@ class GitHubError(Exception):
             #: List of errors provided by GitHub
             if error.get('errors'):
                 self.errors = error.get('errors')
-        except:  # Amazon S3 error
+        except Exception:  # Amazon S3 error
             self.msg = resp.content or '[No message]'
 
     def __repr__(self):

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -216,10 +216,10 @@ class TestGitHub(IntegrationHelper):
         """Test the ability to retrieve a list of gitignore templates."""
         cassette_name = self.cassette_name('gitignore_templates')
         with self.recorder.use_cassette(cassette_name):
-            l = self.gh.gitignore_templates()
+            thelist = self.gh.gitignore_templates()
 
-        assert l != []
-        assert isinstance(l, list)
+        assert thelist != []
+        assert isinstance(thelist, list)
 
     def test_is_following(self):
         """Test the ability to check if a user is being followed."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35,py},py{27,34}-flake8,docstrings
+envlist = py{27,34,35,py},py{27,34}-flake8,docstrings
 minversion = 2.5.0
 
 [testenv]


### PR DESCRIPTION
Ran into these in an unrelated PR.

Don't have a bare except

Don't use single char variables

Drop py33 testing, that release is no longer supported by pytest and
they are EOL upstream as well.
( https://github.com/pytest-dev/pytest/issues/2812 )

This is an alternate to #744

Signed-off-by: Jesse Keating <jkeating@j2solutions.net>