### PR TITLE
Add exception to indicate an incomplete data set

### DIFF
--- a/github3/exceptions.py
+++ b/github3/exceptions.py
@@ -34,6 +34,22 @@ class GitHubError(Exception):
         return self.msg
 
 
+class IncompleteResponse(GitHubError):
+    """Exception for a response that doesn't have everything it should."""
+
+    def __init__(self, json, exception):
+        self.response = None
+        self.code = None
+        self.json = json
+        self.errors = []
+        self.exception = exception
+        self.msg = (
+            "The library was expecting more data in the response (%r)."
+            " Either GitHub modified it's response body, or your token"
+            " is not properly scoped to retrieve this information."
+        ) % (exception,)
+
+
 class ResponseError(GitHubError):
     """The base exception for errors stemming from GitHub responses."""
     pass

--- a/github3/models.py
+++ b/github3/models.py
@@ -48,7 +48,10 @@ class GitHubCore(object):
             self.last_modified = json.pop('Last-Modified', None)
             self._uniq = json.get('url', None)
         self._json_data = json
-        self._update_attributes(json)
+        try:
+            self._update_attributes(json)
+        except KeyError as kerr:
+            raise exceptions.IncompleteResponse(json, kerr)
 
     def _update_attributes(self, json):
         pass


### PR DESCRIPTION
This communicates far more clearly to the user what may have happened to
cause issues with the response they were expecting. In the case of the
issue raised, this points people towards the token they may be using and
its scopes.

Closes #693

Care to review @omgjlk ?