### PR TITLE
Use the issue's Session object on issue.milestone

### DIFF
--- a/github3/issues/issue.py
+++ b/github3/issues/issue.py
@@ -83,7 +83,7 @@ class _Issue(models.GitHubCore):
         #: issue was assigned to.
         self.milestone = issue['milestone']
         if self.milestone:
-            self.milestone = Milestone(self.milestone)
+            self.milestone = Milestone(self.milestone, self)
 
         #: Issue number (e.g. #15)
         self.number = issue['number']


### PR DESCRIPTION
Without passing in "self" to the Milestone for the issue.milestone
attribute, we were getting a completely brand-new GitHubSession. This
meant that we were failing to use Betamax which caused our tests to be
unreliable and to bypass Betamax while running the test-suite.