### PR TITLE
Ensure a session is passed through to GitHubCore

### DIFF
--- a/github3/events.py
+++ b/github3/events.py
@@ -119,7 +119,7 @@ class Event(GitHubCore):
         event = copy.deepcopy(event)
 
         #: :class:`User <github3.users.User>` object representing the actor.
-        self.actor = self._class_attribute(event, 'actor', EventUser)
+        self.actor = self._class_attribute(event, 'actor', EventUser, self)
         #: datetime object representing when the event was created.
         self.created_at = self._strptime_attribute(event, 'created_at')
 
@@ -127,7 +127,7 @@ class Event(GitHubCore):
         self.id = self._get_attribute(event, 'id')
 
         #: List all possible types of Events
-        self.org = self._class_attribute(event, 'org', EventOrganization)
+        self.org = self._class_attribute(event, 'org', EventOrganization, self)
 
         #: Event type https://developer.github.com/v3/activity/events/types/
         self.type = self._get_attribute(event, 'type')

--- a/github3/gists/gist.py
+++ b/github3/gists/gist.py
@@ -314,7 +314,7 @@ class GistFork(GitHubCore):
     def _update_attributes(self, fork):
         self.created_at = self._strptime(fork['created_at'])
         self.id = fork['id']
-        self.owner = users.ShortUser(fork['user'])
+        self.owner = users.ShortUser(fork['user'], self)
         self.updated_at = self._strptime(fork['updated_at'])
         self.url = self._api = fork['url']
 

--- a/github3/git.py
+++ b/github3/git.py
@@ -193,7 +193,7 @@ class Tree(GitData):
         #: list of :class:`Hash <Hash>` objects
         self.tree = self._get_attribute(tree, 'tree', [])
         if self.tree:
-            self.tree = [Hash(t) for t in self.tree]
+            self.tree = [Hash(t, self) for t in self.tree]
 
     def _repr(self):
         return '<Tree [{0}]>'.format(self.sha)

--- a/github3/git.py
+++ b/github3/git.py
@@ -108,7 +108,7 @@ class Reference(GitHubCore):
         self.ref = self._get_attribute(ref, 'ref')
 
         #: :class:`GitObject <GitObject>` the reference points to
-        self.object = self._class_attribute(ref, 'object', GitObject)
+        self.object = self._class_attribute(ref, 'object', GitObject, self)
 
     def _repr(self):
         return '<Reference [{0}]>'.format(self.ref)
@@ -173,7 +173,7 @@ class Tag(GitData):
         self.tagger = self._get_attribute(tag, 'tagger')
 
         #: :class:`GitObject <GitObject>` for the tag
-        self.object = self._class_attribute(tag, 'object', GitObject)
+        self.object = self._class_attribute(tag, 'object', GitObject, self)
 
     def _repr(self):
         return '<Tag [{0}]>'.format(self.tag)

--- a/github3/github.py
+++ b/github3/github.py
@@ -80,7 +80,7 @@ class GitHub(GitHubCore):
         if addresses:
             url = self._build_url('user', 'emails')
             json = self._json(self._post(url, data=addresses), 201)
-        return [users.Email(email) for email in json] if json else []
+        return [users.Email(email, self) for email in json] if json else []
 
     def all_events(self, number=-1, etag=None):
         """Iterate over public events.

--- a/github3/github.py
+++ b/github3/github.py
@@ -57,7 +57,7 @@ class GitHub(GitHubCore):
     """
 
     def __init__(self, username='', password='', token=''):
-        super(GitHub, self).__init__({})
+        super(GitHub, self).__init__({}, self.new_session())
         if token:
             self.login(username, token=token)
         elif username and password:
@@ -1795,7 +1795,7 @@ class GitHubStatus(GitHubCore):
     return the JSON objects returned by the API.
     """
     def __init__(self):
-        super(GitHubStatus, self).__init__({})
+        super(GitHubStatus, self).__init__({}, self.new_session())
         self.session.base_url = 'https://status.github.com'
 
     def _repr(self):

--- a/github3/issues/issue.py
+++ b/github3/issues/issue.py
@@ -34,11 +34,11 @@ class _Issue(models.GitHubCore):
         #: was assigned to.
         self.assignee = issue['assignee']
         if self.assignee:
-            self.assignee = users.ShortUser(self.assignee)
+            self.assignee = users.ShortUser(self.assignee, self)
         self.assignees = issue['assignees']
         if self.assignees:
             self.assignees = [
-                users.ShortUser(assignee) for assignee in self.assignees
+                users.ShortUser(assignee, self) for assignee in self.assignees
             ]
 
         #: Body (description) of the issue.
@@ -107,7 +107,7 @@ class _Issue(models.GitHubCore):
         self.updated_at = self._strptime_attribute(issue, 'updated_at')
 
         #: :class:`User <github3.users.User>` who opened the issue.
-        self.user = users.ShortUser(issue['user'])
+        self.user = users.ShortUser(issue['user'], self)
 
     def _repr(self):
         return '<Issue [{r[0]}/{r[1]} #{n}]>'.format(r=self.repository,
@@ -389,4 +389,4 @@ class Issue(_Issue):
         #: :class:`User <github3.users.User>` who closed the issue.
         self.closed_by = issue['closed_by']
         if self.closed_by:
-            self.closed_by = users.ShortUser(self.closed_by)
+            self.closed_by = users.ShortUser(self.closed_by, self)

--- a/github3/models.py
+++ b/github3/models.py
@@ -32,12 +32,10 @@ class GitHubCore(object):
     have.
     """
 
-    def __init__(self, json, session=None):
+    def __init__(self, json, session):
         if hasattr(session, 'session'):
             # i.e. session is actually a GitHubCore instance
             session = session.session
-        elif session is None:
-            session = GitHubSession()
         self.session = session
 
         # set a sane default
@@ -165,14 +163,14 @@ class GitHubCore(object):
         return repr_string
 
     @classmethod
-    def from_dict(cls, json_dict):
+    def from_dict(cls, json_dict, session):
         """Return an instance of this class formed from ``json_dict``."""
-        return cls(json_dict)
+        return cls(json_dict, session)
 
     @classmethod
-    def from_json(cls, json):
+    def from_json(cls, json, session):
         """Return an instance of this class formed from ``json``."""
-        return cls(loads(json))
+        return cls(loads(json), session)
 
     def __eq__(self, other):
         return self._uniq == other._uniq
@@ -347,6 +345,10 @@ class GitHubCore(object):
             self._json_data = json
             self._update_attributes(json)
         return self
+
+    def new_session(self):
+        """Helper function to generate a new session"""
+        return GitHubSession()
 
 
 class BaseComment(GitHubCore):

--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -24,8 +24,8 @@ class PullDestination(models.GitHubCore):
         http://developer.github.com/v3/pulls/#get-a-single-pull-request
     """
 
-    def __init__(self, dest, direction):
-        super(PullDestination, self).__init__(dest)
+    def __init__(self, dest, direction, session=None):
+        super(PullDestination, self).__init__(dest, session)
         from .repos.repo import ShortRepository
         #: Direction of the merge with respect to this destination
         self.direction = direction
@@ -36,7 +36,7 @@ class PullDestination(models.GitHubCore):
         #: :class:`User <github3.users.User>` representing the owner
         self.user = None
         if dest.get('user'):
-            self.user = users.ShortUser(dest.get('user'), None)
+            self.user = users.ShortUser(dest.get('user'), self)
         #: SHA of the commit at the head
         self.sha = dest.get('sha')
         self._repo_name = ''
@@ -118,7 +118,7 @@ class _PullRequest(models.GitHubCore):
         self._api = pull['url']
 
         #: Base of the merge
-        self.base = PullDestination(pull['base'], 'Base')
+        self.base = PullDestination(pull['base'], 'Base', self)
 
         #: Body of the pull request message
         self.body = pull['body']
@@ -136,7 +136,7 @@ class _PullRequest(models.GitHubCore):
         self.created_at = self._strptime_attribute(pull, 'created_at')
 
         #: The new head after the pull request
-        self.head = PullDestination(pull['head'], 'Head')
+        self.head = PullDestination(pull['head'], 'Head', self)
 
         #: The unique id of the pull request
         self.id = self._get_attribute(pull, 'id')
@@ -175,7 +175,7 @@ class _PullRequest(models.GitHubCore):
 
         #: :class:`User <github3.users.ShortUser>` object representing the
         #:  creator of the pull request
-        self.user = users.ShortUser(pull['user'])
+        self.user = users.ShortUser(pull['user'], self)
 
         # This is only present if the PR has been assigned.
         #: :class:`User <github3.users.ShortUser>` object representing the

--- a/github3/repos/comparison.py
+++ b/github3/repos/comparison.py
@@ -69,7 +69,7 @@ class Comparison(GitHubCore):
         #: objects.
         self.commits = self._get_attribute(compare, 'commits', [])
         if self.commits:
-            self.commits = [RepoCommit(com) for com in self.commits]
+            self.commits = [RepoCommit(com, self) for com in self.commits]
 
         #: List of dicts describing the files modified.
         self.files = self._get_attribute(compare, 'files', [])

--- a/github3/repos/pages.py
+++ b/github3/repos/pages.py
@@ -37,7 +37,8 @@ class PagesBuild(GitHubCore):
         from .. import users
         #: :class:`User <github3.users.User>` representing who pushed the
         #: commit
-        self.pusher = self._class_attribute(build, 'pusher', users.ShortUser)
+        self.pusher = self._class_attribute(build, 'pusher', users.ShortUser,
+                                            self)
 
         #: SHA of the commit that triggered the build
         self.commit = self._get_attribute(build, 'commit')

--- a/github3/repos/release.py
+++ b/github3/repos/release.py
@@ -65,7 +65,7 @@ class Release(models.GitHubCore):
 
         #: :class:`User <github3.users.ShortUser>` object representing the
         #:  creator of the release
-        self.author = users.ShortUser(release['author'])
+        self.author = users.ShortUser(release['author'], self)
 
         #: URLs to various attributes
         for urltype in ['assets_url', 'html_url', 'tarball_url',

--- a/github3/repos/status.py
+++ b/github3/repos/status.py
@@ -74,7 +74,7 @@ class CombinedStatus(GitHubCore):
         #: List of :class:`Status <github3.repos.status.Status>`
         #: objects.
         statuses = self._get_attribute(combined_status, 'statuses', [])
-        self.statuses = [Status(s) for s in statuses]
+        self.statuses = [Status(s, self) for s in statuses]
 
         from . import repo
         #: Repository the combined status belongs too.

--- a/github3/repos/status.py
+++ b/github3/repos/status.py
@@ -31,7 +31,7 @@ class Status(GitHubCore):
 
         #: :class:`User <github3.users.User>` who created the object
         self.creator = self._class_attribute(
-            status, 'creator', users.ShortUser
+            status, 'creator', users.ShortUser, self
         )
 
         #: Short description of the Status

--- a/github3/users.py
+++ b/github3/users.py
@@ -608,7 +608,7 @@ class AuthenticatedUser(User):
         self.total_private_repos = user['total_private_repos']
 
         #: Which plan this user is on
-        self.plan = Plan(user['plan'])
+        self.plan = Plan(user['plan'], self)
 
         #: Number of repo contributions. Only appears in ``repo.contributors``
         contributions = user.get('contributions')

--- a/tests/unit/helper.py
+++ b/tests/unit/helper.py
@@ -85,7 +85,8 @@ class UnitHelper(unittest.TestCase):
             instance = self.described_class(self.example_data,
                                             self.session)
         elif self.example_data and not self.session:
-            instance = self.described_class(self.example_data)
+            session = self.create_session_mock()
+            instance = self.described_class(self.example_data, session)
 
         else:
             instance = self.described_class()

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -37,7 +37,7 @@ class TestEvent(UnitHelper):
         json = self.instance.as_dict().copy()
         org = get_org_example_data()
         json['org'] = org
-        event = github3.events.Event(json)
+        event = github3.events.Event(json, self.session)
         assert isinstance(event.org, github3.events.EventOrganization)
 
 

--- a/tests/unit/test_gists.py
+++ b/tests/unit/test_gists.py
@@ -200,7 +200,8 @@ class TestGistHistory(helper.UnitHelper):
     def test_equality(self):
         """Show that two instances of a GistHistory are equal."""
         history = github3.gists.history.GistHistory(
-            gist_history_example_data()
+            gist_history_example_data(),
+            self.session
         )
         assert self.instance == history
         history._uniq = 'foo'
@@ -222,7 +223,8 @@ class TestGistComment(helper.UnitHelper):
     def test_equality(self):
         """Show that two instances of a GistComment are equal."""
         comment = github3.gists.comment.GistComment(
-            gist_comment_example_data()
+            gist_comment_example_data(),
+            self.session
         )
         assert self.instance == comment
         comment._uniq = '1'

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -23,12 +23,12 @@ class TestTree(UnitHelper):
 
     def test_eq(self):
         """Assert that two trees are equal."""
-        tree = github3.git.Tree(get_example_data())
+        tree = github3.git.Tree(get_example_data(), self.session)
         assert self.instance == tree
 
     def test_ne(self):
         """Assert that two trees are not equal."""
-        tree = github3.git.Tree(get_example_data())
+        tree = github3.git.Tree(get_example_data(), self.session)
         tree._json_data['truncated'] = True
         assert self.instance != tree
 

--- a/tests/unit/test_issues_issue.py
+++ b/tests/unit/test_issues_issue.py
@@ -225,11 +225,11 @@ class TestIssue(helper.UnitHelper):
     def test_enterprise(self):
         """Show that enterprise data can be instantiated as Issue."""
         json = helper.create_example_data_helper('issue_enterprise')()
-        assert github3.issues.Issue(json)
+        assert github3.issues.Issue(json, self.session)
 
     def test_equality(self):
         """Show that two instances of Issue are equal."""
-        issue = github3.issues.Issue(get_issue_example_data())
+        issue = github3.issues.Issue(get_issue_example_data(), self.session)
         assert self.instance == issue
 
         issue._uniq = 1
@@ -247,7 +247,8 @@ class TestIssue(helper.UnitHelper):
         GitHub sometimes returns `pull` as part of of the `html_url` for Issue
         requests.
         """
-        issue = Issue(helper.create_example_data_helper('issue_137')())
+        issue = Issue(helper.create_example_data_helper('issue_137')(),
+                      self.session)
         self.assertEqual(
             issue.html_url,
             "https://github.com/sigmavirus24/github3.py/pull/1")
@@ -392,7 +393,7 @@ class TestLabel(helper.UnitHelper):
 
     def test_equality(self):
         """Show that two instances of Label are equal."""
-        label = Label(get_issue_label_example_data())
+        label = Label(get_issue_label_example_data(), self.session)
         assert self.instance == label
 
         label._uniq = ('https://https//api.github.com/repos/sigmavirus24/'
@@ -444,7 +445,8 @@ class TestIssueEvent(helper.UnitHelper):
     def test_equality(self):
         """Show that two instances of IssueEvent are equal."""
         issue_event = github3.issues.event.IssueEvent(
-            get_issue_event_example_data()
+            get_issue_event_example_data(),
+            self.session
         )
 
         assert self.instance == issue_event

--- a/tests/unit/test_issues_milestone.py
+++ b/tests/unit/test_issues_milestone.py
@@ -50,14 +50,14 @@ class TestMilestone(helper.UnitHelper):
         """Show that creator is None when json attribute is set to None."""
         json = self.instance.as_dict().copy()
         json['creator'] = None
-        milestone = github3.issues.milestone.Milestone(json)
+        milestone = github3.issues.milestone.Milestone(json, self.session)
         assert milestone.creator is None
 
     def test_due_on(self):
         """Show that due on attribute is a datetime object."""
         json = self.instance.as_dict().copy()
         json['due_on'] = '2012-12-31T23:59:59Z'
-        milestone = github3.issues.milestone.Milestone(json)
+        milestone = github3.issues.milestone.Milestone(json, self.session)
         assert isinstance(milestone.due_on, datetime.datetime)
 
     def test_repr(self):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -12,7 +12,7 @@ from . import helper
 
 class MyTestRefreshClass(GitHubCore):
     """Subclass for testing refresh on GitHubCore."""
-    def __init__(self, example_data, session=None):
+    def __init__(self, example_data, session):
         super(MyTestRefreshClass, self).__init__(example_data, session)
         self._api = example_data['url']
         self.last_modified = example_data['last_modified']
@@ -105,7 +105,7 @@ class TestGitHubCore(helper.UnitHelper):
 
     def test_from_json(self):
         """Verify that method returns GitHubObject from json."""
-        github_core = GitHubCore.from_json('{}')
+        github_core = GitHubCore.from_json('{}', self.session)
         assert isinstance(github_core, GitHubCore)
 
     def test_instance_or_null(self):

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -16,7 +16,7 @@ class TestThread(UnitHelper):
 
     def test_equality(self):
         """Test equality/inequality between two instances."""
-        thread = github3.notifications.Thread(get_example_data())
+        thread = github3.notifications.Thread(get_example_data(), self.session)
         assert self.instance == thread
         thread._uniq = 1
         assert self.instance != thread

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -142,7 +142,7 @@ class TestProjectColumn(helper.UnitHelper):
     def test_create_card_with_issue(self):
         """Show that a user can create a new project card with an Issue."""
         issue_data = get_issue_example_data()
-        issue = issues.Issue(issue_data)
+        issue = issues.Issue(issue_data, self.session)
 
         self.instance.create_card_with_issue(issue)
         self.post_called_with(

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -36,7 +36,7 @@ class TestUser(helper.UnitHelper):
 
     def test_equality(self):
         """Show that two instances are equal."""
-        user = github3.users.User(get_users_example_data())
+        user = github3.users.User(get_users_example_data(), self.session)
         self.instance == user
 
         user._uniq += 1
@@ -88,7 +88,7 @@ class TestUserKey(helper.UnitHelper):
 
     def test_equality(self):
         """Show that two instances of Key are equal."""
-        key = github3.users.Key(get_user_key_example_data())
+        key = github3.users.Key(get_user_key_example_data(), self.session)
         assert self.instance == key
 
         key._uniq += "cruft"


### PR DESCRIPTION
Unless a session (or a self) is passed through a new session might be
created, which can lead to some interesting things. See #770

This also adds a session class argument for PullDestination and updates
the calls to it.

A future commit will make the session argument of GitHubCore
nonoptional.

Related-to: #771

Signed-off-by: Jesse Keating <omgjlk@github.com>