### PR TITLE
Allow library to be used by Github Apps

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -156,3 +156,5 @@ Contributors
 - Becca James (@beccasjames)
 
 - Walid Ziouche (@01walid)
+
+- Robert Hafner (@tedivm)

--- a/github3/api.py
+++ b/github3/api.py
@@ -40,7 +40,8 @@ def authorize(username, password, scopes, note='', note_url='', client_id='',
                         client_secret)
 
 
-def login(username=None, password=None, token=None, two_factor_callback=None, app=False):
+def login(username=None, password=None, token=None, two_factor_callback=None,
+          app=False):
     """Construct and return an authenticated GitHub session.
 
     .. note::

--- a/github3/api.py
+++ b/github3/api.py
@@ -40,7 +40,7 @@ def authorize(username, password, scopes, note='', note_url='', client_id='',
                         client_secret)
 
 
-def login(username=None, password=None, token=None, two_factor_callback=None):
+def login(username=None, password=None, token=None, two_factor_callback=None, app=False):
     """Construct and return an authenticated GitHub session.
 
     .. note::
@@ -61,7 +61,7 @@ def login(username=None, password=None, token=None, two_factor_callback=None):
 
     if (username and password) or token:
         g = GitHub()
-        g.login(username, password, token, two_factor_callback)
+        g.login(username, password, token, two_factor_callback, app)
 
     return g
 

--- a/github3/github.py
+++ b/github3/github.py
@@ -776,7 +776,8 @@ class GitHub(GitHubCore):
 
         # If running as an App the `Accept` header needs to change.
         if app:
-            self.session.headers['Accept'] == 'application/vnd.github.machine-man-preview+json'
+            apptype = 'application/vnd.github.machine-man-preview+json'
+            self.session.headers['Accept'] = apptype
 
     def markdown(self, text, mode='', context='', raw=False):
         """Render an arbitrary markdown document.

--- a/github3/github.py
+++ b/github3/github.py
@@ -42,6 +42,7 @@ class GitHub(GitHubCore):
         g = login(user, password)
         g = login(token=token)
         g = login(user, token=token)
+        g = login(token=token, isapp=True)
 
     or
 
@@ -51,13 +52,14 @@ class GitHub(GitHubCore):
         g = GitHub(user, password)
         g = GitHub(token=token)
         g = GitHub(user, token=token)
+        g = GitHub(token=token, isapp=True)
 
     This is simple backward compatibility since originally there was no way to
     call the GitHub object with authentication parameters.
     """
 
-    def __init__(self, username='', password='', token=''):
-        super(GitHub, self).__init__({}, self.new_session())
+    def __init__(self, username='', password='', token='', isapp=False):
+        super(GitHub, self).__init__({}, self.new_session(isapp))
         if token:
             self.login(username, token=token)
         elif username and password:
@@ -755,7 +757,7 @@ class GitHub(GitHubCore):
                           headers=License.CUSTOM_HEADERS)
 
     def login(self, username=None, password=None, token=None,
-              two_factor_callback=None):
+              two_factor_callback=None, app=False):
         """Logs the user into GitHub for protected API calls.
 
         :param str username: login name
@@ -771,6 +773,10 @@ class GitHub(GitHubCore):
 
         # The Session method handles None for free.
         self.session.two_factor_auth_callback(two_factor_callback)
+
+        # If running as an App the `Accept` header needs to change.
+        if app:
+            self.session.headers['Accept'] == 'application/vnd.github.machine-man-preview+json'
 
     def markdown(self, text, mode='', context='', raw=False):
         """Render an arbitrary markdown document.

--- a/github3/models.py
+++ b/github3/models.py
@@ -347,9 +347,9 @@ class GitHubCore(object):
             self._update_attributes(json)
         return self
 
-    def new_session(self):
+    def new_session(self, isapp=False):
         """Helper function to generate a new session"""
-        return GitHubSession()
+        return GitHubSession(isapp)
 
 
 class BaseComment(GitHubCore):

--- a/github3/session.py
+++ b/github3/session.py
@@ -21,7 +21,7 @@ class GitHubSession(requests.Session):
     auth = None
     __attrs__ = requests.Session.__attrs__ + ['base_url', 'two_factor_auth_cb']
 
-    def __init__(self):
+    def __init__(self, isapp=False):
         super(GitHubSession, self).__init__()
         self.headers.update({
             # Only accept JSON responses
@@ -33,6 +33,9 @@ class GitHubSession(requests.Session):
             # Set our own custom User-Agent string
             'User-Agent': 'github3.py/{0}'.format(__version__),
             })
+        if isapp:
+            self.headers['Accept'] = 'application/vnd.github.machine-man-preview+json'
+
         self.base_url = 'https://api.github.com'
         self.two_factor_auth_cb = None
         self.request_counter = 0

--- a/github3/session.py
+++ b/github3/session.py
@@ -34,7 +34,8 @@ class GitHubSession(requests.Session):
             'User-Agent': 'github3.py/{0}'.format(__version__),
             })
         if isapp:
-            self.headers['Accept'] = 'application/vnd.github.machine-man-preview+json'
+            apptype = 'application/vnd.github.machine-man-preview+json'
+            self.headers['Accept'] = apptype
 
         self.base_url = 'https://api.github.com'
         self.two_factor_auth_cb = None

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -108,7 +108,7 @@ class TestAPI(unittest.TestCase):
 
     def test_login(self):
         """Show that github3.login proxies to GitHub."""
-        args = ('login', 'password', None, None)
+        args = ('login', 'password', None, None, False)
         with mock.patch.object(github3.GitHub, 'login') as login:
             g = github3.login(*args)
             assert isinstance(g, github3.GitHub)

--- a/tests/unit/test_github_session.py
+++ b/tests/unit/test_github_session.py
@@ -34,7 +34,8 @@ class TestGitHubSession:
         """Assert the default headers are there upon initialization"""
         s = session.GitHubSession(isapp=True)
         assert 'Accept' in s.headers
-        assert s.headers['Accept'] == 'application/vnd.github.machine-man-preview+json'
+        accepttype = 'application/vnd.github.machine-man-preview+json'
+        assert s.headers['Accept'] == accepttype
         assert 'Accept-Charset' in s.headers
         assert s.headers['Accept-Charset'] == 'utf-8'
         assert 'Content-Type' in s.headers

--- a/tests/unit/test_github_session.py
+++ b/tests/unit/test_github_session.py
@@ -30,6 +30,18 @@ class TestGitHubSession:
         assert 'User-Agent' in s.headers
         assert s.headers['User-Agent'].startswith('github3.py/')
 
+    def test_has_appt_headers(self):
+        """Assert the default headers are there upon initialization"""
+        s = session.GitHubSession(isapp=True)
+        assert 'Accept' in s.headers
+        assert s.headers['Accept'] == 'application/vnd.github.machine-man-preview+json'
+        assert 'Accept-Charset' in s.headers
+        assert s.headers['Accept-Charset'] == 'utf-8'
+        assert 'Content-Type' in s.headers
+        assert s.headers['Content-Type'] == 'application/json'
+        assert 'User-Agent' in s.headers
+        assert s.headers['User-Agent'].startswith('github3.py/')
+
     def test_build_url(self):
         """Test that GitHubSessions build basic URLs"""
         s = self.build_session()


### PR DESCRIPTION
To be used by Github Apps the Accept Header needs to include `application/vnd.github.machine-man-preview+json`.

I'd definitely appreciate a review and any feedback, as this is the first time I've dug into this codebase. I'll be testing this further with the application I'm working on.

This should resolve #784.