### PR TITLE
Allow .refresh to return the longer object

### DIFF
--- a/github3/gists/file.py
+++ b/github3/gists/file.py
@@ -32,6 +32,33 @@ class _GistFile(models.GitHubCore):
         return None
 
 
+class GistFile(_GistFile):
+    """This represents the full file object returned by interacting with gists.
+
+    The object has all of the attributes as returned by the API for a
+    ShortGistFile as well as:
+
+    .. attribute:: truncated
+
+        A boolean attribute that indicates whether :attr:`original_content`
+        contains all of the file's contents.
+
+    .. attribute:: original_content
+
+        The contents of the file (potentially truncated) returned by the API.
+        If the file was truncated use :meth:`content` to retrieve it in its
+        entirety.
+
+    """
+
+    class_name = 'GistFile'
+
+    def _update_attributes(self, gistfile):
+        super(GistFile, self)._update_attributes(gistfile)
+        self.original_content = gistfile['content']
+        self.truncated = gistfile['truncated']
+
+
 class ShortGistFile(_GistFile):
     """This represents the file object returned by interacting with gists.
 
@@ -60,30 +87,4 @@ class ShortGistFile(_GistFile):
     """
 
     class_name = 'ShortGistFile'
-
-
-class GistFile(_GistFile):
-    """This represents the full file object returned by interacting with gists.
-
-    The object has all of the attributes as returned by the API for a
-    ShortGistFile as well as:
-
-    .. attribute:: truncated
-
-        A boolean attribute that indicates whether :attr:`original_content`
-        contains all of the file's contents.
-
-    .. attribute:: original_content
-
-        The contents of the file (potentially truncated) returned by the API.
-        If the file was truncated use :meth:`content` to retrieve it in its
-        entirety.
-
-    """
-
-    class_name = 'GistFile'
-
-    def _update_attributes(self, gistfile):
-        super(GistFile, self)._update_attributes(gistfile)
-        self.original_content = gistfile['content']
-        self.truncated = gistfile['truncated']
+    _refresh_to = GistFile

--- a/github3/gists/gist.py
+++ b/github3/gists/gist.py
@@ -228,87 +228,6 @@ class _Gist(models.GitHubCore):
         return self._boolean(self._delete(url), 204, 404)
 
 
-class ShortGist(_Gist):
-    """Short representation of a gist.
-
-    GitHub's API returns different amounts of information about gists
-    based upon how that information is retrieved. This object exists to
-    represent the full amount of information returned for a specific
-    gist. For example, you would receive this class when calling
-    :meth:`~github3.github.GitHub.all_gists`. To provide a clear distinction
-    between the types of gists, github3.py uses different classes with
-    different sets of attributes.
-
-    This object only has the following attributes:
-
-    .. attribute:: url
-
-        The GitHub API URL for this repository, e.g.,
-        ``https://api.github.com/gists/6faaaeb956dec3f51a9bd630a3490291``.
-
-    .. attribute:: comments_count
-
-        Number of comments on this gist
-
-    .. attribute:: description
-
-        Description of the gist as written by the creator
-
-    .. attribute:: html_url
-
-        The URL of this gist on GitHub, e.g.,
-        ``https://gist.github.com/sigmavirus24/6faaaeb956dec3f51a9bd630a3490291``
-
-    .. attribute:: id
-
-        The unique identifier for this gist.
-
-    .. attribute:: public
-
-        This is a boolean attribute  describing if the gist is public or
-        private
-
-    .. attribute:: git_pull_url
-
-        The git URL to pull this gist, e.g.,
-        ``git://gist.github.com/sigmavirus24/6faaaeb956dec3f51a9bd630a3490291.git``
-
-    .. attribute:: git_push_url
-
-        The git URL to push to gist, e.g.,
-        ``git@gist.github.com/sigmavirus24/6faaaeb956dec3f51a9bd630a3490291.git``
-
-    .. attribute:: created_at
-
-        This is a datetime object representing when the gist was created.
-
-    .. attribute:: updated_at
-        This is a datetime object representing the last time this gist was
-        most recently updated.
-
-    .. attribute:: owner
-
-        This attribute is a :class:`~github3.users.ShortUser` object
-        representing the creator of the gist.
-
-    .. attribute:: files
-
-        A dictionary mapping the filename to a
-        :class:`~github3.gists.gist.GistFile` object.
-
-        .. versionchanged:: 1.0.0
-
-            Previously this was a list but it has been converted to a
-            dictionary to preserve the structure of the API.
-
-    .. attribute:: comments_url
-
-        The URL to retrieve the list of comments on the Gist via the API.
-    """
-
-    class_name = 'ShortGist'
-
-
 class GistFork(models.GitHubCore):
     """This object represents a forked Gist.
 
@@ -409,3 +328,85 @@ class Gist(_Gist):
         self.forks_url = gist['forks_url']
         self.history = [history.GistHistory(h, self) for h in gist['history']]
         self.truncated = gist['truncated']
+
+
+class ShortGist(_Gist):
+    """Short representation of a gist.
+
+    GitHub's API returns different amounts of information about gists
+    based upon how that information is retrieved. This object exists to
+    represent the full amount of information returned for a specific
+    gist. For example, you would receive this class when calling
+    :meth:`~github3.github.GitHub.all_gists`. To provide a clear distinction
+    between the types of gists, github3.py uses different classes with
+    different sets of attributes.
+
+    This object only has the following attributes:
+
+    .. attribute:: url
+
+        The GitHub API URL for this repository, e.g.,
+        ``https://api.github.com/gists/6faaaeb956dec3f51a9bd630a3490291``.
+
+    .. attribute:: comments_count
+
+        Number of comments on this gist
+
+    .. attribute:: description
+
+        Description of the gist as written by the creator
+
+    .. attribute:: html_url
+
+        The URL of this gist on GitHub, e.g.,
+        ``https://gist.github.com/sigmavirus24/6faaaeb956dec3f51a9bd630a3490291``
+
+    .. attribute:: id
+
+        The unique identifier for this gist.
+
+    .. attribute:: public
+
+        This is a boolean attribute  describing if the gist is public or
+        private
+
+    .. attribute:: git_pull_url
+
+        The git URL to pull this gist, e.g.,
+        ``git://gist.github.com/sigmavirus24/6faaaeb956dec3f51a9bd630a3490291.git``
+
+    .. attribute:: git_push_url
+
+        The git URL to push to gist, e.g.,
+        ``git@gist.github.com/sigmavirus24/6faaaeb956dec3f51a9bd630a3490291.git``
+
+    .. attribute:: created_at
+
+        This is a datetime object representing when the gist was created.
+
+    .. attribute:: updated_at
+        This is a datetime object representing the last time this gist was
+        most recently updated.
+
+    .. attribute:: owner
+
+        This attribute is a :class:`~github3.users.ShortUser` object
+        representing the creator of the gist.
+
+    .. attribute:: files
+
+        A dictionary mapping the filename to a
+        :class:`~github3.gists.gist.GistFile` object.
+
+        .. versionchanged:: 1.0.0
+
+            Previously this was a list but it has been converted to a
+            dictionary to preserve the structure of the API.
+
+    .. attribute:: comments_url
+
+        The URL to retrieve the list of comments on the Gist via the API.
+    """
+
+    class_name = 'ShortGist'
+    _refresh_to = Gist

--- a/github3/git.py
+++ b/github3/git.py
@@ -174,7 +174,7 @@ class ShortCommit(_Commit):
     """
 
     class_name = 'ShortCommit'
-    refresh_to = Commit
+    _refresh_to = Commit
 
 
 class Reference(models.GitHubCore):

--- a/github3/issues/issue.py
+++ b/github3/issues/issue.py
@@ -369,6 +369,47 @@ class _Issue(models.GitHubCore):
         return self._boolean(self._delete(url), 204, 404)
 
 
+class Issue(_Issue):
+    """Object for the full representation of an Issue.
+
+    GitHub's API returns different amounts of information about issues based
+    upon how that information is retrieved. This object exists to represent
+    the full amount of information returned for a specific issue. For example,
+    you would receive this class when calling
+    :meth:`~github3.github.GitHub.issue`. To provide a clear
+    distinction between the types of issues, github3.py uses different classes
+    with different sets of attributes.
+
+    .. versionchanged:: 1.0.0
+
+    This object has all of the same attributes as a
+    :class:`~github3.issues.issue.ShortIssue` as well as the following:
+
+    .. attribute:: body_html
+
+        The HTML formatted body of this issue.
+
+    .. attribute:: body_text
+
+        The plain-text formatted body of this issue.
+
+    .. attribute:: closed_by
+
+        If the issue is closed, a :class:`~github3.users.ShortUser`
+        representing the user who closed the issue.
+    """
+
+    class_name = 'Issue'
+
+    def _update_attributes(self, issue):
+        super(Issue, self)._update_attributes(issue)
+        self.body_html = issue['body_html']
+        self.body_text = issue['body_text']
+        self.closed_by = issue['closed_by']
+        if self.closed_by:
+            self.closed_by = users.ShortUser(self.closed_by, self)
+
+
 class ShortIssue(_Issue):
     """Object for the shortened representation of an Issue.
 
@@ -481,43 +522,5 @@ class ShortIssue(_Issue):
         this issue.
     """
 
-    pass
-
-
-class Issue(_Issue):
-    """Object for the full representation of an Issue.
-
-    GitHub's API returns different amounts of information about issues based
-    upon how that information is retrieved. This object exists to represent
-    the full amount of information returned for a specific issue. For example,
-    you would receive this class when calling
-    :meth:`~github3.github.GitHub.issue`. To provide a clear
-    distinction between the types of issues, github3.py uses different classes
-    with different sets of attributes.
-
-    .. versionchanged:: 1.0.0
-
-    This object has all of the same attributes as a
-    :class:`~github3.issues.issue.ShortIssue` as well as the following:
-
-    .. attribute:: body_html
-
-        The HTML formatted body of this issue.
-
-    .. attribute:: body_text
-
-        The plain-text formatted body of this issue.
-
-    .. attribute:: closed_by
-
-        If the issue is closed, a :class:`~github3.users.ShortUser`
-        representing the user who closed the issue.
-    """
-
-    def _update_attributes(self, issue):
-        super(Issue, self)._update_attributes(issue)
-        self.body_html = issue['body_html']
-        self.body_text = issue['body_text']
-        self.closed_by = issue['closed_by']
-        if self.closed_by:
-            self.closed_by = users.ShortUser(self.closed_by, self)
+    class_name = 'ShortIssue'
+    _refresh_to = Issue

--- a/github3/licenses.py
+++ b/github3/licenses.py
@@ -26,32 +26,6 @@ class _License(models.GitHubCore):
         return '<{0} [{1}]>'.format(self.class_name, self.name)
 
 
-class ShortLicense(_License):
-    """This object represents a license returned in a collection.
-
-    GitHub's API returns different representations of objects in different
-    contexts. This object reprsents a license that would be returned in a
-    collection, e.g., retrieving all licenses from ``/licenses``.
-
-    This object has the following attributes:
-
-    .. attribute:: key
-
-        The short, API name, for this license.
-
-    .. attribute:: name
-
-        The long form, legal name for this license.
-
-    .. attribute:: spdx_id
-
-        The Software Package Data Exchange (a.k.a, SPDX) identifier for this
-        license.
-    """
-
-    class_name = 'ShortLicense'
-
-
 class License(_License):
     """This object represents a license as returned by the GitHub API.
 
@@ -95,6 +69,8 @@ class License(_License):
         A list of the permissions granted by this license.
     """
 
+    class_name = 'License'
+
     def _update_attributes(self, license):
         super(License, self)._update_attributes(license)
         self.body = license['body']
@@ -108,6 +84,33 @@ class License(_License):
 
     def _repr(self):
         return '<License [{0}]>'.format(self.name)
+
+
+class ShortLicense(_License):
+    """This object represents a license returned in a collection.
+
+    GitHub's API returns different representations of objects in different
+    contexts. This object reprsents a license that would be returned in a
+    collection, e.g., retrieving all licenses from ``/licenses``.
+
+    This object has the following attributes:
+
+    .. attribute:: key
+
+        The short, API name, for this license.
+
+    .. attribute:: name
+
+        The long form, legal name for this license.
+
+    .. attribute:: spdx_id
+
+        The Software Package Data Exchange (a.k.a, SPDX) identifier for this
+        license.
+    """
+
+    class_name = 'ShortLicense'
+    _refresh_to = License
 
 
 class RepositoryLicense(models.GitHubCore):

--- a/github3/models.py
+++ b/github3/models.py
@@ -24,6 +24,7 @@ class GitHubCore(object):
     """
 
     _ratelimit_resource = 'core'
+    _refresh_to = None
 
     def __init__(self, json, session):
         """Initialize our basic object.
@@ -282,8 +283,11 @@ class GitHubCore(object):
         headers = headers or None
         json = self._json(self._get(self._api, headers=headers), 200)
         if json is not None:
-            self._json_data = json
-            self._update_attributes(json)
+            if self._refresh_to is None:
+                self._json_data = json
+                self._update_attributes(json)
+            else:
+                return self._refresh_to(json, self)
         return self
 
     def new_session(self):

--- a/github3/orgs.py
+++ b/github3/orgs.py
@@ -262,6 +262,52 @@ class _Team(models.GitHubCore):
         return self._boolean(self._delete(url), 204, 404)
 
 
+class Team(_Team):
+    """Object representing a team in the GitHub API.
+
+    In addition to the attributes on a :class:`~github3.orgs.ShortTeam` a Team
+    has the following attribute:
+
+    .. attribute:: created_at
+
+        A :class:`~datetime.datetime` instance representing the time and date
+        when this team was created.
+
+    .. attribute:: members_count
+
+        The number of members in this team.
+
+    .. attribute:: organization
+
+        A :class:`~github3.orgs.ShortOrganization` representing the
+        organization this team belongs to.
+
+    .. attribute:: repos_count
+
+        The number of repositories this team can access.
+
+    .. attribute:: updated_at
+
+        A :class:`~datetime.datetime` instance representing the time and date
+        when this team was updated.
+
+    Please see GitHub's `Team Documentation`_ for more information.
+
+    .. _Team Documentation:
+        http://developer.github.com/v3/orgs/teams/
+    """
+
+    class_name = 'Team'
+
+    def _update_attributes(self, team):
+        super(Team, self)._update_attributes(team)
+        self.created_at = self._strptime(team['created_at'])
+        self.members_count = team['members_count']
+        self.organization = ShortOrganization(team['organization'], self)
+        self.repos_count = team['repos_count']
+        self.updated_at = self._strptime(team['updated_at'])
+
+
 class ShortTeam(_Team):
     """Object representing a team in the GitHub API.
 
@@ -309,52 +355,7 @@ class ShortTeam(_Team):
     """
 
     class_name = 'ShortTeam'
-
-
-class Team(_Team):
-    """Object representing a team in the GitHub API.
-
-    In addition to the attributes on a :class:`~github3.orgs.ShortTeam` a Team
-    has the following attribute:
-
-    .. attribute:: created_at
-
-        A :class:`~datetime.datetime` instance representing the time and date
-        when this team was created.
-
-    .. attribute:: members_count
-
-        The number of members in this team.
-
-    .. attribute:: organization
-
-        A :class:`~github3.orgs.ShortOrganization` representing the
-        organization this team belongs to.
-
-    .. attribute:: repos_count
-
-        The number of repositories this team can access.
-
-    .. attribute:: updated_at
-
-        A :class:`~datetime.datetime` instance representing the time and date
-        when this team was updated.
-
-    Please see GitHub's `Team Documentation`_ for more information.
-
-    .. _Team Documentation:
-        http://developer.github.com/v3/orgs/teams/
-    """
-
-    class_name = 'Team'
-
-    def _update_attributes(self, team):
-        super(Team, self)._update_attributes(team)
-        self.created_at = self._strptime(team['created_at'])
-        self.members_count = team['members_count']
-        self.organization = ShortOrganization(team['organization'], self)
-        self.repos_count = team['repos_count']
-        self.updated_at = self._strptime(team['updated_at'])
+    _refresh_to = Team
 
 
 class _Organization(models.GitHubCore):
@@ -898,76 +899,6 @@ class _Organization(models.GitHubCore):
         return self._instance_or_null(Team, json)
 
 
-class ShortOrganization(_Organization):
-    """Object for the shortened representation of an Organization.
-
-    GitHub's API returns different amounts of information about orgs based
-    upon how that information is retrieved. Often times, when iterating over
-    several orgs, GitHub will return less information. To provide a clear
-    distinction between the types of orgs, github3.py uses different classes
-    with different sets of attributes.
-
-    .. versionadded:: 1.0.0
-
-    .. attribute:: avatar_url
-
-        The URL of the avatar image for this organization.
-
-    .. attribute:: description
-
-        The user-provided description of this organization.
-
-    .. attribute:: events_url
-
-        The URL to retrieve the events related to this organization.
-
-    .. attribute:: hooks_url
-
-        The URL for the resource to manage organization hooks.
-
-    .. attribute:: id
-
-        The unique identifier for this organization across GitHub.
-
-    .. attribute:: issues_url
-
-        The URL to retrieve the issues across this organization's
-        repositories.
-
-    .. attribute:: login
-
-        The unique username of the organization.
-
-    .. attribute:: members_url
-
-        The URL to retrieve the members of this organization.
-
-    .. attribute:: public_members_urlt
-
-        A :class:`uritemplate.URITemplate` that can be expanded to either list
-        the public members of this organization or verify a user is a public
-        member.
-
-    .. attribute:: repos_url
-
-        The URL to retrieve the repositories in this organization.
-
-    .. attribute:: url
-
-        The URL to retrieve this organization from the GitHub API.
-
-    .. attribute:: type
-
-        .. deprecated:: 1.0.0
-
-            This will be removed in a future release.
-
-        Previously returned by the API to indicate the type of the account.
-    """
-
-    class_name = 'ShortOrganization'
-
-
 class Organization(_Organization):
     """Object for the full representation of a Organization.
 
@@ -1044,6 +975,77 @@ class Organization(_Organization):
         self.email = org.get('email')
         self.location = org.get('location')
         self.name = org.get('name')
+
+
+class ShortOrganization(_Organization):
+    """Object for the shortened representation of an Organization.
+
+    GitHub's API returns different amounts of information about orgs based
+    upon how that information is retrieved. Often times, when iterating over
+    several orgs, GitHub will return less information. To provide a clear
+    distinction between the types of orgs, github3.py uses different classes
+    with different sets of attributes.
+
+    .. versionadded:: 1.0.0
+
+    .. attribute:: avatar_url
+
+        The URL of the avatar image for this organization.
+
+    .. attribute:: description
+
+        The user-provided description of this organization.
+
+    .. attribute:: events_url
+
+        The URL to retrieve the events related to this organization.
+
+    .. attribute:: hooks_url
+
+        The URL for the resource to manage organization hooks.
+
+    .. attribute:: id
+
+        The unique identifier for this organization across GitHub.
+
+    .. attribute:: issues_url
+
+        The URL to retrieve the issues across this organization's
+        repositories.
+
+    .. attribute:: login
+
+        The unique username of the organization.
+
+    .. attribute:: members_url
+
+        The URL to retrieve the members of this organization.
+
+    .. attribute:: public_members_urlt
+
+        A :class:`uritemplate.URITemplate` that can be expanded to either list
+        the public members of this organization or verify a user is a public
+        member.
+
+    .. attribute:: repos_url
+
+        The URL to retrieve the repositories in this organization.
+
+    .. attribute:: url
+
+        The URL to retrieve this organization from the GitHub API.
+
+    .. attribute:: type
+
+        .. deprecated:: 1.0.0
+
+            This will be removed in a future release.
+
+        Previously returned by the API to indicate the type of the account.
+    """
+
+    class_name = 'ShortOrganization'
+    _refresh_to = Organization
 
 
 class Membership(models.GitHubCore):

--- a/github3/pulls.py
+++ b/github3/pulls.py
@@ -185,6 +185,8 @@ class _PullRequest(models.GitHubCore):
         http://developer.github.com/v3/pulls/
     """
 
+    class_name = '_PullRequest'
+
     def _update_attributes(self, pull):
         self._api = pull['url']
         self.assignee = pull['assignee']
@@ -221,7 +223,7 @@ class _PullRequest(models.GitHubCore):
         self.user = users.ShortUser(pull['user'], self)
 
     def _repr(self):
-        return '<Pull Request [#{0}]>'.format(self.number)
+        return '<{0} [#{1}]>'.format(self.class_name, self.number)
 
     @requires_auth
     def close(self):
@@ -496,6 +498,81 @@ class _PullRequest(models.GitHubCore):
         return False
 
 
+class PullRequest(_PullRequest):
+    """Object for the full representation of a PullRequest.
+
+    GitHub's API returns different amounts of information about prs based
+    upon how that information is retrieved. This object exists to represent
+    the full amount of information returned for a specific pr. For example,
+    you would receive this class when calling
+    :meth:`~github3.github.GitHub.pull_request`. To provide a clear
+    distinction between the types of prs, github3.py uses different classes
+    with different sets of attributes.
+
+    .. versionchanged:: 1.0.0
+
+    This object has all of the same attributes as
+    :class:`~github3.pulls.ShortPullRequest` as well as the following:
+
+    .. attribute:: additions_count
+
+        The number of lines of code added in this pull request.
+
+    .. attribute:: deletions_count
+
+        The number of lines of code deleted in this pull request.
+
+    .. attribute:: comments_count
+
+        The number of comments left on this pull request.
+
+    .. attribute:: commits_count
+
+        The number of commits included in this pull request.
+
+    .. attribute:: mergeable
+
+        A boolean attribute indicating whether GitHub deems this pull request
+        is mergeable.
+
+    .. attribute:: mergeable_state
+
+        A string indicating whether this would be a 'clean' or 'dirty' merge.
+
+    .. attribute:: merged
+
+        A boolean attribute indicating whether the pull request has been merged
+        or not.
+
+    .. attribute:: merged_by
+
+        An instance of :class:`~github3.users.ShortUser` to indicate the user
+        who merged this pull request. If this hasn't been merged or if
+        :attr:`mergeable` is still being decided by GitHub this will be
+        ``None``.
+
+    .. attribute:: review_comments_count
+
+        The number of review comments on this pull request.
+    """
+
+    class_name = 'Pull Request'
+
+    def _update_attributes(self, pull):
+        super(PullRequest, self)._update_attributes(pull)
+        self.additions_count = pull['additions']
+        self.deletions_count = pull['deletions']
+        self.comments_count = pull['comments']
+        self.commits_count = pull['commits']
+        self.mergeable = pull['mergeable']
+        self.mergeable_state = pull['mergeable_state']
+        self.merged = pull['merged']
+        self.merged_by = pull['merged_by']
+        if self.merged_by is not None:
+            self.merged_by = users.ShortUser(self.merged_by, self)
+        self.review_comments_count = pull['review_comments']
+
+
 class ShortPullRequest(_PullRequest):
     """Object for the shortened representation of a PullRequest.
 
@@ -646,80 +723,8 @@ class ShortPullRequest(_PullRequest):
         this pull request.
     """
 
-    pass
-
-
-class PullRequest(_PullRequest):
-    """Object for the full representation of a PullRequest.
-
-    GitHub's API returns different amounts of information about prs based
-    upon how that information is retrieved. This object exists to represent
-    the full amount of information returned for a specific pr. For example,
-    you would receive this class when calling
-    :meth:`~github3.github.GitHub.pull_request`. To provide a clear
-    distinction between the types of prs, github3.py uses different classes
-    with different sets of attributes.
-
-    .. versionchanged:: 1.0.0
-
-    This object has all of the same attributes as
-    :class:`~github3.pulls.ShortPullRequest` as well as the following:
-
-    .. attribute:: additions_count
-
-        The number of lines of code added in this pull request.
-
-    .. attribute:: deletions_count
-
-        The number of lines of code deleted in this pull request.
-
-    .. attribute:: comments_count
-
-        The number of comments left on this pull request.
-
-    .. attribute:: commits_count
-
-        The number of commits included in this pull request.
-
-    .. attribute:: mergeable
-
-        A boolean attribute indicating whether GitHub deems this pull request
-        is mergeable.
-
-    .. attribute:: mergeable_state
-
-        A string indicating whether this would be a 'clean' or 'dirty' merge.
-
-    .. attribute:: merged
-
-        A boolean attribute indicating whether the pull request has been merged
-        or not.
-
-    .. attribute:: merged_by
-
-        An instance of :class:`~github3.users.ShortUser` to indicate the user
-        who merged this pull request. If this hasn't been merged or if
-        :attr:`mergeable` is still being decided by GitHub this will be
-        ``None``.
-
-    .. attribute:: review_comments_count
-
-        The number of review comments on this pull request.
-    """
-
-    def _update_attributes(self, pull):
-        super(PullRequest, self)._update_attributes(pull)
-        self.additions_count = pull['additions']
-        self.deletions_count = pull['deletions']
-        self.comments_count = pull['comments']
-        self.commits_count = pull['commits']
-        self.mergeable = pull['mergeable']
-        self.mergeable_state = pull['mergeable_state']
-        self.merged = pull['merged']
-        self.merged_by = pull['merged_by']
-        if self.merged_by is not None:
-            self.merged_by = users.ShortUser(self.merged_by, self)
-        self.review_comments_count = pull['review_comments']
+    class_name = 'Short Pull Request'
+    _refresh_to = PullRequest
 
 
 class PullReview(models.GitHubCore):

--- a/github3/repos/branch.py
+++ b/github3/repos/branch.py
@@ -93,32 +93,6 @@ class _Branch(models.GitHubCore):
         return True
 
 
-class ShortBranch(_Branch):
-    """The representation of a branch returned in a collection.
-
-    GitHub's API returns different amounts of information about repositories
-    based upon how that information is retrieved. This object exists to
-    represent the limited amount of information returned for a specific
-    branch in a collection. For example, you would receive this class when
-    calling :meth:`~github3.repos.repo.Repository.branches`. To provide a
-    clear distinction between the types of branches, github3.py uses different
-    classes with different sets of attributes.
-
-    This object has the following attributes:
-
-    .. attribute:: commit
-
-        A :class:`~github3.repos.commit.MiniCommit` representation of the
-        newest commit on this branch with the associated repository metadata.
-
-    .. attribute:: name
-
-        The name of this branch.
-    """
-
-    class_name = 'Short Repository Branch'
-
-
 class Branch(_Branch):
     """The representation of a branch returned in a collection.
 
@@ -169,3 +143,30 @@ class Branch(_Branch):
             # Branches obtained via `repo.branches` don't have links.
             base = self.commit.url.split('/commit', 1)[0]
             self._api = self._build_url('branches', self.name, base_url=base)
+
+
+class ShortBranch(_Branch):
+    """The representation of a branch returned in a collection.
+
+    GitHub's API returns different amounts of information about repositories
+    based upon how that information is retrieved. This object exists to
+    represent the limited amount of information returned for a specific
+    branch in a collection. For example, you would receive this class when
+    calling :meth:`~github3.repos.repo.Repository.branches`. To provide a
+    clear distinction between the types of branches, github3.py uses different
+    classes with different sets of attributes.
+
+    This object has the following attributes:
+
+    .. attribute:: commit
+
+        A :class:`~github3.repos.commit.MiniCommit` representation of the
+        newest commit on this branch with the associated repository metadata.
+
+    .. attribute:: name
+
+        The name of this branch.
+    """
+
+    class_name = 'Short Repository Branch'
+    _refresh_to = Branch

--- a/github3/repos/comment.py
+++ b/github3/repos/comment.py
@@ -79,6 +79,29 @@ class _RepoComment(models.GitHubCore):
     update = edit
 
 
+class RepoComment(_RepoComment):
+    """The representation of the full comment on an object in a repository.
+
+    This object has the same attributes as a
+    :class:`~github3.repos.comment.ShortComment` as well as the following:
+
+    .. attribute:: body_html
+
+        The HTML formatted text of this comment.
+
+    .. attribute:: body_text
+
+        The plain-text formatted text of this comment.
+    """
+
+    class_name = 'Repository Comment'
+
+    def _update_attributes(self, comment):
+        super(RepoComment, self)._update_attributes(comment)
+        self.body_text = comment['body_text']
+        self.body_html = comment['body_html']
+
+
 class ShortComment(_RepoComment):
     """The representation of an abridged comment on an object in a repo.
 
@@ -133,26 +156,4 @@ class ShortComment(_RepoComment):
     """
 
     class_name = 'Short Repository Comment'
-
-
-class RepoComment(_RepoComment):
-    """The representation of the full comment on an object in a repository.
-
-    This object has the same attributes as a
-    :class:`~github3.repos.comment.ShortComment` as well as the following:
-
-    .. attribute:: body_html
-
-        The HTML formatted text of this comment.
-
-    .. attribute:: body_text
-
-        The plain-text formatted text of this comment.
-    """
-
-    class_name = 'Repository Comment'
-
-    def _update_attributes(self, comment):
-        super(RepoComment, self)._update_attributes(comment)
-        self.body_text = comment['body_text']
-        self.body_html = comment['body_html']
+    _refresh_to = RepoComment

--- a/github3/repos/commit.py
+++ b/github3/repos/commit.py
@@ -100,34 +100,6 @@ class _RepoCommit(models.GitHubCore):
         return self._iter(int(number), url, RepoComment, etag=etag)
 
 
-class MiniCommit(_RepoCommit):
-    """A commit returned on a ShortBranch."""
-
-    class_name = 'Mini Repository Commit'
-
-
-class ShortCommit(_RepoCommit):
-    """Representation of an incomplete commit in a collection."""
-
-    class_name = 'Short Repository Commit'
-
-    def _update_attributes(self, commit):
-        super(ShortCommit, self)._update_attributes(commit)
-        self.author = commit['author']
-        if self.author:
-            self.author = users.ShortUser(self.author, self)
-        self.comments_url = commit['comments_url']
-        self.commit = git.ShortCommit(commit['commit'], self)
-        self.committer = commit['committer']
-        if self.committer:
-            self.committer = users.ShortUser(self.committer, self)
-        self.html_url = commit['html_url']
-        #: List of parents to this commit.
-        self.parents = commit['parents']
-        #: The commit message
-        self.message = getattr(self.commit, 'message', None)
-
-
 class RepoCommit(_RepoCommit):
     """Representation of a commit with repository and git data."""
 
@@ -148,3 +120,33 @@ class RepoCommit(_RepoCommit):
             self.additions = self.stats['additions']
             self.deletions = self.stats['deletions']
             self.total = self.stats['total']
+
+
+class MiniCommit(_RepoCommit):
+    """A commit returned on a ShortBranch."""
+
+    class_name = 'Mini Repository Commit'
+    _refresh_to = RepoCommit
+
+
+class ShortCommit(_RepoCommit):
+    """Representation of an incomplete commit in a collection."""
+
+    class_name = 'Short Repository Commit'
+    _refresh_to = RepoCommit
+
+    def _update_attributes(self, commit):
+        super(ShortCommit, self)._update_attributes(commit)
+        self.author = commit['author']
+        if self.author:
+            self.author = users.ShortUser(self.author, self)
+        self.comments_url = commit['comments_url']
+        self.commit = git.ShortCommit(commit['commit'], self)
+        self.committer = commit['committer']
+        if self.committer:
+            self.committer = users.ShortUser(self.committer, self)
+        self.html_url = commit['html_url']
+        #: List of parents to this commit.
+        self.parents = commit['parents']
+        #: The commit message
+        self.message = getattr(self.commit, 'message', None)

--- a/github3/repos/repo.py
+++ b/github3/repos/repo.py
@@ -2290,6 +2290,187 @@ class _Repository(models.GitHubCore):
         return json
 
 
+class Repository(_Repository):
+    """This organizes the full representation of a single Repository.
+
+    The full representation of a Repository is not returned in collections but
+    instead in individual requests, e.g.,
+    :meth:`~github3.github.GitHub.repository`.
+
+    This object has all the same attributes as
+    :class:`~github3.repos.repo.ShortRepository` as well as:
+
+    .. attribute:: archived
+
+        A boolean attribute that describes whether the current repository has
+        been archived or not.
+
+    .. attribute:: clone_url
+
+        This is the URL that can be used to clone the repository via HTTPS,
+        e.g., ``https://github.com/sigmavirus24/github3.py.git``.
+
+    .. attribute:: created_at
+
+        A parsed :class:`~datetime.datetime` object representing the date the
+        repository was created.
+
+    .. attribute:: default_branch
+
+        This is the default branch of the repository as configured by its
+        administrator(s).
+
+    .. attribute:: forks_count
+
+        This is the number of forks of the repository.
+
+    .. attribute:: git_url
+
+        This is the URL that can be used to clone the repository via the Git
+        protocol, e.g., ``git://github.com/sigmavirus24/github3.py``.
+
+    .. attribute:: has_downloads
+
+        This is a boolean attribute that conveys whether or not the repository
+        has downloads.
+
+    .. attribute:: has_issues
+
+        This is a boolean attribute that conveys whether or not the repository
+        has issues.
+
+    .. attribute:: has_pages
+
+        This is a boolean attribute that conveys whether or not the repository
+        has pages.
+
+    .. attribute:: has_wiki
+
+        This is a boolean attribute that conveys whether or not the repository
+        has a wiki.
+
+    .. attribute:: homepage
+
+        This is the administrator set homepage URL for the project. This may
+        not be provided.
+
+    .. attribute:: language
+
+        This is the language GitHub has detected for the repository.
+
+    .. attribute:: original_license
+
+        This is the :class:`~github3.license.ShortLicense` returned as part of
+        the repository. To retrieve the most recent license, see the
+        :meth:`~github3.repos.repo.Repository.license` method.
+
+    .. attribute:: mirror_url
+
+        The URL that GitHub is mirroring the repository from.
+
+    .. attribute:: network_count
+
+        The size of the repository's "network".
+
+    .. attribute:: open_issues_count
+
+        The number of issues currently open on the repository.
+
+    .. attribute:: parent
+
+        A representation of the parent repository as
+        :class:`~github3.repos.repo.ShortRepository`. If this Repository has
+        no parent then this will be ``None``.
+
+    .. attribute:: pushed_at
+
+        A parsed :class:`~datetime.datetime` object representing the date a
+        push was last made to the repository.
+
+    .. attribute:: size
+
+        The size of the repository.
+
+    .. attribute:: source
+
+        A representation of the source repository as
+        :class:`~github3.repos.repo.ShortRepository`. If this Repository has
+        no source then this will be ``None``.
+
+    .. attribute:: ssh_url
+
+        This is the URL that can be used to clone the repository via the SSH
+        protocol, e.g., ``ssh@github.com:sigmavirus24/github3.py.git``.
+
+    .. attribute:: stargazers_count
+
+        The number of people who have starred this repository.
+
+    .. attribute:: subscribers_count
+
+        The number of people watching (or who have subscribed to notifications
+        about) this repository.
+
+    .. attribute:: svn_url
+
+        This is the URL that can be used to clone the repository via SVN,
+        e.g., ``ssh@github.com:sigmavirus24/github3.py.git``.
+
+    .. attribute:: updated_at
+
+        A parsed :class:`~datetime.datetime` object representing the date a
+        the repository was last updated by its administrator(s).
+
+    .. attribute:: watchers_count
+
+        The number of people watching this repository.
+
+
+    See also: http://developer.github.com/v3/repos/
+    """
+
+    class_name = 'Repository'
+
+    def _update_attributes(self, repo):
+        super(Repository, self)._update_attributes(repo)
+        self.archived = repo['archived']
+        self.clone_url = repo['clone_url']
+        self.created_at = self._strptime(repo['created_at'])
+        self.default_branch = repo['default_branch']
+        self.forks_count = repo['forks_count']
+        self.fork_count = self.forks_count
+        self.git_url = repo['git_url']
+        self.has_downloads = repo['has_downloads']
+        self.has_issues = repo['has_issues']
+        self.has_pages = repo['has_pages']
+        self.has_projects = repo['has_projects']
+        self.has_wiki = repo['has_wiki']
+        self.homepage = repo['homepage']
+        self.language = repo['language']
+        self.original_license = repo['license']
+        if self.original_license is not None:
+            self.original_license = licenses.ShortLicense(
+                self.original_license, self
+            )
+        self.mirror_url = repo['mirror_url']
+        self.network_count = repo['network_count']
+        self.open_issues_count = repo['open_issues_count']
+        self.parent = repo.get('parent', None)
+        if self.parent is not None:
+            self.parent = ShortRepository(self.parent, self)
+        self.pushed_at = self._strptime(repo['pushed_at'])
+        self.size = repo['size']
+        self.source = repo.get('source', None)
+        if self.source is not None:
+            self.source = ShortRepository(self.source, self)
+        self.ssh_url = repo['ssh_url']
+        self.stargazers_count = repo['stargazers_count']
+        self.subscribers_count = repo['subscribers_count']
+        self.svn_url = repo['svn_url']
+        self.updated_at = self._strptime(repo['updated_at'])
+        self.watchers_count = self.watchers = repo['watchers_count']
+
+
 class ShortRepository(_Repository):
     """This represents a Repository object returned in collections.
 
@@ -2558,187 +2739,7 @@ class ShortRepository(_Repository):
     """
 
     class_name = 'ShortRepository'
-
-
-class Repository(_Repository):
-    """This organizes the full representation of a single Repository.
-
-    The full representation of a Repository is not returned in collections but
-    instead in individual requests, e.g.,
-    :meth:`~github3.github.GitHub.repository`.
-
-    This object has all the same attributes as
-    :class:`~github3.repos.repo.ShortRepository` as well as:
-
-    .. attribute:: archived
-
-        A boolean attribute that describes whether the current repository has
-        been archived or not.
-
-    .. attribute:: clone_url
-
-        This is the URL that can be used to clone the repository via HTTPS,
-        e.g., ``https://github.com/sigmavirus24/github3.py.git``.
-
-    .. attribute:: created_at
-
-        A parsed :class:`~datetime.datetime` object representing the date the
-        repository was created.
-
-    .. attribute:: default_branch
-
-        This is the default branch of the repository as configured by its
-        administrator(s).
-
-    .. attribute:: forks_count
-
-        This is the number of forks of the repository.
-
-    .. attribute:: git_url
-
-        This is the URL that can be used to clone the repository via the Git
-        protocol, e.g., ``git://github.com/sigmavirus24/github3.py``.
-
-    .. attribute:: has_downloads
-
-        This is a boolean attribute that conveys whether or not the repository
-        has downloads.
-
-    .. attribute:: has_issues
-
-        This is a boolean attribute that conveys whether or not the repository
-        has issues.
-
-    .. attribute:: has_pages
-
-        This is a boolean attribute that conveys whether or not the repository
-        has pages.
-
-    .. attribute:: has_wiki
-
-        This is a boolean attribute that conveys whether or not the repository
-        has a wiki.
-
-    .. attribute:: homepage
-
-        This is the administrator set homepage URL for the project. This may
-        not be provided.
-
-    .. attribute:: language
-
-        This is the language GitHub has detected for the repository.
-
-    .. attribute:: original_license
-
-        This is the :class:`~github3.license.ShortLicense` returned as part of
-        the repository. To retrieve the most recent license, see the
-        :meth:`~github3.repos.repo.Repository.license` method.
-
-    .. attribute:: mirror_url
-
-        The URL that GitHub is mirroring the repository from.
-
-    .. attribute:: network_count
-
-        The size of the repository's "network".
-
-    .. attribute:: open_issues_count
-
-        The number of issues currently open on the repository.
-
-    .. attribute:: parent
-
-        A representation of the parent repository as
-        :class:`~github3.repos.repo.ShortRepository`. If this Repository has
-        no parent then this will be ``None``.
-
-    .. attribute:: pushed_at
-
-        A parsed :class:`~datetime.datetime` object representing the date a
-        push was last made to the repository.
-
-    .. attribute:: size
-
-        The size of the repository.
-
-    .. attribute:: source
-
-        A representation of the source repository as
-        :class:`~github3.repos.repo.ShortRepository`. If this Repository has
-        no source then this will be ``None``.
-
-    .. attribute:: ssh_url
-
-        This is the URL that can be used to clone the repository via the SSH
-        protocol, e.g., ``ssh@github.com:sigmavirus24/github3.py.git``.
-
-    .. attribute:: stargazers_count
-
-        The number of people who have starred this repository.
-
-    .. attribute:: subscribers_count
-
-        The number of people watching (or who have subscribed to notifications
-        about) this repository.
-
-    .. attribute:: svn_url
-
-        This is the URL that can be used to clone the repository via SVN,
-        e.g., ``ssh@github.com:sigmavirus24/github3.py.git``.
-
-    .. attribute:: updated_at
-
-        A parsed :class:`~datetime.datetime` object representing the date a
-        the repository was last updated by its administrator(s).
-
-    .. attribute:: watchers_count
-
-        The number of people watching this repository.
-
-
-    See also: http://developer.github.com/v3/repos/
-    """
-
-    class_name = 'Repository'
-
-    def _update_attributes(self, repo):
-        super(Repository, self)._update_attributes(repo)
-        self.archived = repo['archived']
-        self.clone_url = repo['clone_url']
-        self.created_at = self._strptime(repo['created_at'])
-        self.default_branch = repo['default_branch']
-        self.forks_count = repo['forks_count']
-        self.fork_count = self.forks_count
-        self.git_url = repo['git_url']
-        self.has_downloads = repo['has_downloads']
-        self.has_issues = repo['has_issues']
-        self.has_pages = repo['has_pages']
-        self.has_projects = repo['has_projects']
-        self.has_wiki = repo['has_wiki']
-        self.homepage = repo['homepage']
-        self.language = repo['language']
-        self.original_license = repo['license']
-        if self.original_license is not None:
-            self.original_license = licenses.ShortLicense(
-                self.original_license, self
-            )
-        self.mirror_url = repo['mirror_url']
-        self.network_count = repo['network_count']
-        self.open_issues_count = repo['open_issues_count']
-        self.parent = repo.get('parent', None)
-        if self.parent is not None:
-            self.parent = ShortRepository(self.parent, self)
-        self.pushed_at = self._strptime(repo['pushed_at'])
-        self.size = repo['size']
-        self.source = repo.get('source', None)
-        if self.source is not None:
-            self.source = ShortRepository(self.source, self)
-        self.ssh_url = repo['ssh_url']
-        self.stargazers_count = repo['stargazers_count']
-        self.subscribers_count = repo['subscribers_count']
-        self.svn_url = repo['svn_url']
-        self.updated_at = self._strptime(repo['updated_at'])
-        self.watchers_count = self.watchers = repo['watchers_count']
+    _refresh_to = Repository
 
 
 class StarredRepository(models.GitHubCore):

--- a/github3/repos/status.py
+++ b/github3/repos/status.py
@@ -27,6 +27,28 @@ class _Status(models.GitHubCore):
         return '<{s.class_name} [{s.id}:{s.state}]>'.format(s=self)
 
 
+class Status(_Status):
+    """Representation of a full status on a repository.
+
+    See also: http://developer.github.com/v3/repos/statuses/
+
+    This object has the same attributes as a
+    :class:`~github3.repos.status.ShortStatus` as well as the following
+    attributes:
+
+    .. attribute:: creator
+
+        A :class:`~github3.users.ShortUser` representing the user who created
+        this status.
+    """
+
+    class_name = 'Status'
+
+    def _update_attributes(self, status):
+        super(Status, self)._update_attributes(status)
+        self.creator = users.ShortUser(status['creator'], self)
+
+
 class ShortStatus(_Status):
     """Representation of a short status on a repository.
 
@@ -78,28 +100,7 @@ class ShortStatus(_Status):
     """
 
     class_name = 'ShortStatus'
-
-
-class Status(_Status):
-    """Representation of a full status on a repository.
-
-    See also: http://developer.github.com/v3/repos/statuses/
-
-    This object has the same attributes as a
-    :class:`~github3.repos.status.ShortStatus` as well as the following
-    attributes:
-
-    .. attribute:: creator
-
-        A :class:`~github3.users.ShortUser` representing the user who created
-        this status.
-    """
-
-    class_name = 'Status'
-
-    def _update_attributes(self, status):
-        super(Status, self)._update_attributes(status)
-        self.creator = users.ShortUser(status['creator'], self)
+    _refresh_to = Status
 
 
 class CombinedStatus(GitHubCore):

--- a/github3/users.py
+++ b/github3/users.py
@@ -505,99 +505,6 @@ class _User(models.GitHubCore):
         return self._boolean(self._delete(url), 204, 403)
 
 
-class ShortUser(_User):
-    """Object for the shortened representation of a User.
-
-    GitHub's API returns different amounts of information about users based
-    upon how that information is retrieved. Often times, when iterating over
-    several users, GitHub will return less information. To provide a clear
-    distinction between the types of users, github3.py uses different classes
-    with different sets of attributes.
-
-    .. versionadded:: 1.0.0
-
-
-    .. attribute:: avatar_url
-
-        The URL of the avatar (possibly from Gravatar)
-
-    .. attribute:: events_urlt
-
-        A URITemplate object from ``uritemplate`` that can be used to generate
-        an events URL
-
-    .. attribute:: followers_url
-
-        A string representing the resource to retrieve a User's followers
-
-    .. attribute:: following_urlt
-
-        A URITemplate object from ``uritemplate`` that can be used to generate
-        the URL to check if this user is following ``other_user``
-
-    .. attribute:: gists_urlt
-
-        A URITemplate object from ``uritemplate`` that can be used to generate
-        the URL to retrieve a Gist by its id
-
-    .. attribute:: gravatar_id
-
-        The identifier for the user's gravatar
-
-    .. attribute:: html_url
-
-        The URL of the user's publicly visible profile. For example,
-        ``https://github.com/sigmavirus24``
-
-    .. attribute:: id
-
-        The unique ID of the account
-
-    .. attribute:: login
-
-        The username of the user, e.g., ``sigmavirus24``
-
-    .. attribute:: organizations_url
-
-        A string representing the resource to retrieve the organizations to
-        which a user belongs
-
-    .. attribute:: received_events_url
-
-        A string representing the resource to retrieve the events a user
-        received
-
-    .. attribute:: repos_url
-
-        A string representing the resource to list a user's repositories
-
-    .. attribute:: site_admin
-
-        A boolean attribute indicating whether the user is a member of
-        GitHub's staff
-
-    .. attribute:: starred_urlt
-
-        A URITemplate object from ``uritemplate`` that can be used to generate
-        a URL to retrieve whether the user has starred a repository.
-
-    .. attribute:: subscriptions_url
-
-        A string representing the resource to list a user's subscriptions
-
-    .. attribute:: type
-
-        A string representing the type of User account this. In all cases
-        should be "User"
-
-    .. attribute:: url
-
-        A string of this exact resource retrievable from GitHub's API
-    """
-
-    class_name = 'ShortUser'
-
-
 class Contributor(_User):
     """Object for the specialized representation of a contributor.
 
@@ -713,6 +620,100 @@ class User(_User):
         self.public_gists_count = user['public_gists']
         self.public_repos_count = user['public_repos']
         self.updated_at = self._strptime(user['updated_at'])
+
+
+class ShortUser(_User):
+    """Object for the shortened representation of a User.
+
+    GitHub's API returns different amounts of information about users based
+    upon how that information is retrieved. Often times, when iterating over
+    several users, GitHub will return less information. To provide a clear
+    distinction between the types of users, github3.py uses different classes
+    with different sets of attributes.
+
+    .. versionadded:: 1.0.0
+
+
+    .. attribute:: avatar_url
+
+        The URL of the avatar (possibly from Gravatar)
+
+    .. attribute:: events_urlt
+
+        A URITemplate object from ``uritemplate`` that can be used to generate
+        an events URL
+
+    .. attribute:: followers_url
+
+        A string representing the resource to retrieve a User's followers
+
+    .. attribute:: following_urlt
+
+        A URITemplate object from ``uritemplate`` that can be used to generate
+        the URL to check if this user is following ``other_user``
+
+    .. attribute:: gists_urlt
+
+        A URITemplate object from ``uritemplate`` that can be used to generate
+        the URL to retrieve a Gist by its id
+
+    .. attribute:: gravatar_id
+
+        The identifier for the user's gravatar
+
+    .. attribute:: html_url
+
+        The URL of the user's publicly visible profile. For example,
+        ``https://github.com/sigmavirus24``
+
+    .. attribute:: id
+
+        The unique ID of the account
+
+    .. attribute:: login
+
+        The username of the user, e.g., ``sigmavirus24``
+
+    .. attribute:: organizations_url
+
+        A string representing the resource to retrieve the organizations to
+        which a user belongs
+
+    .. attribute:: received_events_url
+
+        A string representing the resource to retrieve the events a user
+        received
+
+    .. attribute:: repos_url
+
+        A string representing the resource to list a user's repositories
+
+    .. attribute:: site_admin
+
+        A boolean attribute indicating whether the user is a member of
+        GitHub's staff
+
+    .. attribute:: starred_urlt
+
+        A URITemplate object from ``uritemplate`` that can be used to generate
+        a URL to retrieve whether the user has starred a repository.
+
+    .. attribute:: subscriptions_url
+
+        A string representing the resource to list a user's subscriptions
+
+    .. attribute:: type
+
+        A string representing the type of User account this. In all cases
+        should be "User"
+
+    .. attribute:: url
+
+        A string of this exact resource retrievable from GitHub's API
+    """
+
+    class_name = 'ShortUser'
+    _refresh_to = User
 
 
 class AuthenticatedUser(User):


### PR DESCRIPTION
This adds logic so that Short* classes can return the fuller
representation. For example:

    >>> import github3
    >>> users = [(u, u.refresh()) for u in github3.all_users(10)]
    >>> for short_user, user in users:
    ...     assert isinstance(short_user, github3.users.ShortUser)
    ...     assert isinstance(user, github3.users.User)

Will run without exceptions.

Related to gh-670