### PR TITLE
Handle 304 responses from GitHub when users pass etag

### DIFF
--- a/github3/models.py
+++ b/github3/models.py
@@ -154,9 +154,15 @@ class GitHubCore(object):
         if actual_status_code != expected_status_code:
             if actual_status_code >= 400:
                 raise exceptions.error_for(response)
+
+            if actual_status_code == 304:
+                # Received a response from someone passing in `etag=`
+                return None
+
             LOG.warning('Expected status_code %d but got %d',
                         expected_status_code,
                         actual_status_code)
+
         try:
             ret = response.json()
         except ValueError:


### PR DESCRIPTION
This was an oversight in the behaviour of pre 1.0 _json handling. This
commit makes it explicit and should allow it to continue working.

Refs gh-798


cc @bboe 