### PR TITLE
Fix equality for IssueEvents without a commit.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -156,3 +156,5 @@ Contributors
 - Becca James (@beccasjames)
 
 - Walid Ziouche (@01walid)
+
+- Katie Bell (@katharosada)

--- a/github3/issues/event.py
+++ b/github3/issues/event.py
@@ -89,7 +89,7 @@ class IssueEvent(GitHubCore):
 
         self.event = event['event']
         self.id = event['id']
-        self._uniq = self.commit_id
+        self._uniq = self._api
 
     def _repr(self):
         return '<Issue Event [{0} by {1}]>'.format(

--- a/tests/unit/test_issues_issue.py
+++ b/tests/unit/test_issues_issue.py
@@ -470,7 +470,12 @@ class TestIssueEvent(helper.UnitHelper):
             get_issue_event_example_data(),
             self.session
         )
+        assigned_event = github3.issues.event.IssueEvent(
+            get_issue_assigned_event_example_data(),
+            self.session
+        )
 
+        assert self.instance._uniq is not None
+        assert assigned_event._uniq is not None
         assert self.instance == issue_event
-        issue_event._uniq = 'foo'
-        assert self.instance != issue_event
+        assert self.instance != assigned_event


### PR DESCRIPTION
The `commit_id` field is null/None for issue events which don't involve a specific commit. I've changed it to use the api url of the issue event (I saw this being used for other models).