### PR TITLE
Fix reprs for auth classes with our GitHub object

### DIFF
--- a/github3/github.py
+++ b/github3/github.py
@@ -66,7 +66,7 @@ class GitHub(models.GitHubCore):
 
     def _repr(self):
         if self.session.auth:
-            return '<GitHub [{0[0]}]>'.format(self.session.auth)
+            return '<GitHub [{!r}]>'.format(self.session.auth)
         return '<Anonymous GitHub at 0x{0:x}>'.format(id(self))
 
     @requires_auth

--- a/github3/session.py
+++ b/github3/session.py
@@ -11,15 +11,28 @@ __logs__ = getLogger(__package__)
 
 
 def requires_2fa(response):
+    """Determine whether a response requires us to prompt the user for 2FA."""
     if (response.status_code == 401 and 'X-GitHub-OTP' in response.headers and
             'required' in response.headers['X-GitHub-OTP']):
         return True
     return False
 
 
+class BasicAuth(requests.auth.HTTPBasicAuth):
+    """Sub-class requests's class so we have a nice repr."""
+
+    def __repr__(self):
+        """Use the username as the representation."""
+        return 'basic {}'.format(self.username)
+
+
 class TokenAuth(requests.auth.AuthBase):
     def __init__(self, token):
         self.token = token
+
+    def __repr__(self):
+        """Return a nice view of the token in use."""
+        return 'token {}...'.format(self.token[:4])
 
     def __ne__(self, other):
         return not self == other
@@ -61,7 +74,7 @@ class GitHubSession(requests.Session):
         if not (username and password):
             return
 
-        self.auth = (username, password)
+        self.auth = BasicAuth(username, password)
 
     def build_url(self, *args, **kwargs):
         """Builds a new API url from scratch."""

--- a/tests/unit/test_github_session.py
+++ b/tests/unit/test_github_session.py
@@ -69,13 +69,13 @@ class TestGitHubSession:
             # Make sure we have a clean session to test with
             s = self.build_session()
             s.basic_auth(*auth)
-            assert s.auth != auth
+            assert s.auth != session.BasicAuth(*auth)
 
     def test_basic_login(self):
         """Test that basic auth will work with a valid combination"""
         s = self.build_session()
         s.basic_auth('username', 'password')
-        assert s.auth == ('username', 'password')
+        assert s.auth == session.BasicAuth('username', 'password')
 
     def test_basic_login_disables_token_auth(self):
         """Test that basic auth will remove the Authorization header.
@@ -238,16 +238,16 @@ class TestGitHubSession:
         s = self.build_session()
         s.basic_auth('foo', 'bar')
         with s.temporary_basic_auth('temp', 'pass'):
-            assert s.auth != ('foo', 'bar')
+            assert s.auth != session.BasicAuth('foo', 'bar')
 
-        assert s.auth == ('foo', 'bar')
+        assert s.auth == session.BasicAuth('foo', 'bar')
 
     def test_temporary_basic_auth_replaces_auth(self):
         """Test that temporary_basic_auth sets the proper credentials."""
         s = self.build_session()
         s.basic_auth('foo', 'bar')
         with s.temporary_basic_auth('temp', 'pass'):
-            assert s.auth == ('temp', 'pass')
+            assert s.auth == session.BasicAuth('temp', 'pass')
 
     def test_no_auth(self):
         """Verify that no_auth removes existing authentication."""
@@ -262,7 +262,7 @@ class TestGitHubSession:
 
         pr = s.prepare_request(req)
         assert 'Authorization' in pr.headers
-        assert s.auth == ('user', 'password')
+        assert s.auth == session.BasicAuth('user', 'password')
 
     def test_retrieve_client_credentials_when_set(self):
         """Test that retrieve_client_credentials will return the credentials.


### PR DESCRIPTION
This will prevent tracebacks as seen in gh-829 from reoccurring.

Closes gh-829