### PR TITLE
Return text from Branch.lastest_sha

### DIFF
--- a/github3/repos/branch.py
+++ b/github3/repos/branch.py
@@ -41,6 +41,8 @@ class _Branch(models.GitHubCore):
             (optional), sha to compare against
         :returns:
             string of the SHA or None
+        :rtype:
+            unicode on python 2, str on python 3
         """
         # If-None-Match returns 200 instead of 304 value does not have quotes
         headers = {
@@ -51,7 +53,7 @@ class _Branch(models.GitHubCore):
         url = self._build_url('commits', self.name, base_url=base)
         resp = self._get(url, headers=headers)
         if self._boolean(resp, 200, 304):
-            return resp.content
+            return resp.text
         return None
 
     @decorators.requires_auth

--- a/tests/integration/test_repos_branch.py
+++ b/tests/integration/test_repos_branch.py
@@ -81,4 +81,4 @@ class TestBranch(IntegrationHelper):
             sha = '541468cdfde6cffe55f0cc801186cdffed154a6a'
             latest_sha = branch.latest_sha(differs_from=sha)
 
-        assert latest_sha
+        assert not isinstance(latest_sha, bytes)


### PR DESCRIPTION
This is a unique endpoint and was always intended to return text. Let's
fix that for consistency. It's unlikely people are relying on this
behaviour so I think it's probably safe to change.

Closes gh-818