### PR TITLE
Use a safer retrieve method to fetch git url in git.py:Hash

### DIFF
--- a/github3/git.py
+++ b/github3/git.py
@@ -427,7 +427,7 @@ class Hash(models.GitHubCore):
     """
 
     def _update_attributes(self, info):
-        self._api = info['url']
+        self._api = info.get('url')
         self.mode = info['mode']
         self.path = info['path']
         self.sha = info['sha']
@@ -435,7 +435,7 @@ class Hash(models.GitHubCore):
         self.type = info['type']
 
         if self.type != 'tree':
-            self.size = info['size']
+            self.size = info.get('size')
 
     def _repr(self):
         return '<Hash [{0}]>'.format(self.sha)


### PR DESCRIPTION
I've run into this exception when trying to recurse through a git tree.
`
*** github3.exceptions.IncompleteResponse: None The library was expecting more data in the response (KeyError('url',)). Either GitHub modified it's response body, or your token is not properly scoped to retrieve this information.
`
originating from the Hash class in git.py 

It seems that it is a rare edge case that a repo tree may contain a commit that doesn't have a `url` entry. 

Using `.get()` to me is safer as it doesn't raise a KeyError if `url` is missing - and just returns None instead.

These changes can be applied in other places not using `.get()` too.