### PR TITLE
docs: Replace login() with GitHub()

### DIFF
--- a/docs/source/api-reference/api.rst
+++ b/docs/source/api-reference/api.rst
@@ -18,16 +18,16 @@ To interact with the GitHub API you can either authenticate to access protected
 functionality or you can interact with it anonymously. Authenticating provides
 more functionality to the user (developer).
 
-To authenticate, you may use :func:`github3.login`.
+To authenticate, you may use :class:`~github3.github.GitHub`.
 
-.. autofunction:: github3.login
+.. autoclass:: github3.github.GitHub
 
 With the :class:`~github3.github.GitHub` object that is returned you have
 access to more functionality. See that object's documentation for more
 information.
 
 To use the API anonymously, you can also create a new
-:class:`~github3.github.GitHub` object, e.g.,
+:class:`~github3.github.GitHub` object without parameters, e.g.,
 
 .. code-block:: python
 

--- a/docs/source/api-reference/api.rst
+++ b/docs/source/api-reference/api.rst
@@ -21,6 +21,7 @@ more functionality to the user (developer).
 To authenticate, you may use :class:`~github3.github.GitHub`.
 
 .. autoclass:: github3.github.GitHub
+   :noindex:
 
 With the :class:`~github3.github.GitHub` object that is returned you have
 access to more functionality. See that object's documentation for more

--- a/docs/source/examples/gist.rst
+++ b/docs/source/examples/gist.rst
@@ -11,9 +11,9 @@ Listing gists after authenticating
 
 ::
 
-    from github3 import login
+    from github3 import GitHub
 
-    gh = login(username, password)
+    gh = GitHub(username, password)
     gists = [g for g in gh.iter_gists()]
 
 Creating a gist after authenticating
@@ -21,9 +21,9 @@ Creating a gist after authenticating
 
 ::
 
-    from github3 import login
+    from github3 import GitHub
 
-    gh = login(username, password)
+    gh = GitHub(username, password)
     files = {
         'spam.txt' : {
             'content': 'What... is the air-speed velocity of an unladen swallow?'

--- a/docs/source/examples/git.rst
+++ b/docs/source/examples/git.rst
@@ -13,8 +13,8 @@ involves the ability to create blob objects.
 
 .. code-block:: python
 
-    from github3 import login
-    g = login(username, password)
+    from github3 import GitHub
+    g = GitHub(username, password)
     repo = g.repository('sigmavirus24', 'Todo.txt-python')
     sha = repo.create_blob('Testing blob creation', 'utf-8')
     sha
@@ -35,8 +35,8 @@ GitHub provides tar files for download via tag objects. You can create one via
 
 .. code-block:: python
 
-    from github3 import login
-    g = login(username, password)
+    from github3 import GitHub
+    g = GitHub(username, password)
     repo = g.repository('sigmavirus24', 'github3.py')
     tag = repo.tag('cdba84b4fede2c69cb1ee246b33f49f19475abfa')
     tag

--- a/docs/source/examples/github.rst
+++ b/docs/source/examples/github.rst
@@ -9,11 +9,11 @@ Assumptions
 -----------
 
 I'll just make some basic assumptions for the examples on this page. First,
-let's assume that all you ever import from github3.py is ``login`` and
-``GitHub`` and that you have already received your :class:`GitHub <GitHub>`
+let's assume that all you ever import from github3.py is ``GitHub`` and
+that you have already received your :class:`GitHub <GitHub>`
 object ``g``. That might look like this::
 
-    from github3 import login, GitHub
+    from github3 import GitHub
     from getpass import getpass, getuser
     import sys
     try:
@@ -33,7 +33,7 @@ object ``g``. That might look like this::
         print("Cowardly refusing to login without a username and password.")
         sys.exit(1)
 
-    g = login(user, password)
+    g = GitHub(user, password)
 
 So anywhere you see ``g`` used, you can safely assume that it is an instance
 where a user has authenticated already.

--- a/docs/source/examples/issue.rst
+++ b/docs/source/examples/issue.rst
@@ -12,9 +12,9 @@ of the issue you're concerned with in ``num``.
 
 ::
 
-    from github3 import login
+    from github3 import GitHub
 
-    gh = login(user, pw)
+    gh = GitHub(user, pw)
     issue = gh.issue(user, repo, num)
     if issue.is_closed():
         issue.reopen()
@@ -60,7 +60,7 @@ timestamp(s) for comment(s) too.
 ::
 
    import github3
-   gh = github3.login(token=token)
+   gh = github3.GitHub(token=token)
    issue = {
       'title': 'Documentation issue',
       'body': 'Missing links in index.html',

--- a/docs/source/examples/iterators.rst
+++ b/docs/source/examples/iterators.rst
@@ -11,7 +11,7 @@ looks like this:
 
     import github3
 
-    g = github3.login(USERNAME, PASSWORD)
+    g = github3.GitHub(USERNAME, PASSWORD)
 
     for u in g.iter_all_users():
         add_user_to_database(u)

--- a/docs/source/examples/oauth.rst
+++ b/docs/source/examples/oauth.rst
@@ -60,14 +60,14 @@ privileges, you simply do the following:
 
 ::
 
-    from github3 import login
+    from github3 import GitHub
 
     token = id = ''
     with open(CREDENTIALS_FILE, 'r') as fd:
         token = fd.readline().strip()  # Can't hurt to be paranoid
         id = fd.readline().strip()
 
-    gh = login(token=token)
+    gh = GitHub(token=token)
     auth = gh.authorization(id)
     auth.update(add_scopes=['repo:status', 'gist'], rm_scopes=['user'])
 

--- a/docs/source/examples/two_factor_auth.rst
+++ b/docs/source/examples/two_factor_auth.rst
@@ -30,8 +30,8 @@ For example:
             code = prompt('Enter 2FA code: ')
         return code
 
-    g = github3.login('sigmavirus24', 'my_password',
-                      two_factor_callback=my_two_factor_function)
+    g = github3.GitHub('sigmavirus24', 'my_password',
+                       two_factor_callback=my_two_factor_function)
 
 Then each time the API tells github3.py it requires a Two Factor Authentication
 code, github3.py will call ``my_two_factor_function`` which prompt you for it.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,9 +11,9 @@ user:
 
 .. code-block:: python
 
-    from github3 import login
+    from github3 import GitHub
 
-    gh = login('sigmavirus24', password='<password>')
+    gh = GitHub('sigmavirus24', password='<password>')
 
     sigmavirus24 = gh.me()
     # <AuthenticatedUser [sigmavirus24:Ian Stapleton Cordasco]>

--- a/docs/source/narrative/getting-started.rst
+++ b/docs/source/narrative/getting-started.rst
@@ -36,7 +36,7 @@ and password. You can then do:
 
     import github3
 
-    github = github3.login(username=username, password=password)
+    github = github3.GitHub(username=username, password=password)
 
 Second, you can `generate an access token`_ and use that. Let's presume you
 have a variable bound as ``token`` that contains your access token.
@@ -45,23 +45,23 @@ have a variable bound as ``token`` that contains your access token.
 
     import github3
 
-    github = github3.login(token=token)
+    github = github3.GitHub(token=token)
 
 Third, if you're using a GitHub Enterprise installation you can use similar
-methods above, but you'll need to use :func:`~github3.api.enterprise_login`,
+methods above, but you'll need to use :class:`~github3.github.GitHubEnterprise`,
 e.g.,
 
 .. code-block:: python
 
     import github3
 
-    githubent = github3.enterprise_login(
+    githubent = github3.GitHubEnterprise(
         url='https://github.myenterprise.example.com',
         username=username,
         password=password,
     )
 
-    githubent = github3.enterprise_login(
+    githubent = github3.GitHubEnterprise(
         url='https://github.myenterprise.example.com',
         token=token,
     )
@@ -92,7 +92,7 @@ An example mechanism is as follows:
         return code
 
 
-    github = github3.login(username, password,
+    github = github3.GitHub(username, password,
                            two_factor_callback=second_factor_retrieval)
 
 


### PR DESCRIPTION
According to the docstring for the `GitHub` class in `github3/github.py`:

> There are two ways to log into the GitHub API [...]
>
> This is simple backward compatibility since originally there was no way to call the GitHub object with authentication parameters.

Since the `login()` method is only included for backwards compatibility, the documentation should initialize the `GitHub` object directly.