### PR TITLE
Fixes #846 -- Added description parameter to Repo.create_label

### DIFF
--- a/github3/issues/label.py
+++ b/github3/issues/label.py
@@ -27,6 +27,7 @@ class Label(GitHubCore):
         self._api = label['url']
         self.color = label['color']
         self.name = label['name']
+        self.description = label.get('description')
         self._uniq = self._api
 
     def _repr(self):

--- a/github3/session.py
+++ b/github3/session.py
@@ -110,6 +110,10 @@ class GitHubSession(requests.Session):
         raise NotImplementedError('These features are not implemented yet')
 
     def request(self, *args, **kwargs):
+        if 'headers' in kwargs:
+            headers = kwargs.pop('headers')
+            self.headers.update(headers)
+
         response = super(GitHubSession, self).request(*args, **kwargs)
         self.request_counter += 1
         if requires_2fa(response) and self.two_factor_auth_cb:

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -298,7 +298,8 @@ class TestRepository(helper.UnitHelper):
         self.instance.create_label(**data)
         self.post_called_with(
             url_for('labels'),
-            data=data
+            data=data,
+            headers={'Accept': 'application/vnd.github.symmetra-preview+json'}
         )
 
     def test_create_label_required_name(self):
@@ -327,6 +328,20 @@ class TestRepository(helper.UnitHelper):
         }
         self.instance.create_label(**data)
         assert self.session.post.called is False
+
+    def test_create_label_optional_description(self):
+        """Should accept an optional description for the label."""
+        data = {
+            'name': 'foo',
+            'color': 'fafafa',
+            'description': 'A nice description'
+        }
+        self.instance.create_label(**data)
+        self.post_called_with(
+            url_for('labels'),
+            data=data,
+            headers={'Accept': 'application/vnd.github.symmetra-preview+json'}
+        )
 
     def test_create_milestone(self):
         """Verify the request for creating a milestone."""
@@ -798,7 +813,8 @@ class TestRepository(helper.UnitHelper):
         """Verify the request for retrieving a label on a repository."""
         self.instance.label('bug')
         self.session.get.assert_called_once_with(
-            url_for('labels/bug')
+            url_for('labels/bug'),
+            headers={'Accept': 'application/vnd.github.symmetra-preview+json'}
         )
 
     def test_label_required_name(self):


### PR DESCRIPTION
Hey folks 👋!

I reported [an issue](https://github.com/sigmavirus24/github3.py/issues/846) a few days ago about labels missing the `description` parameter, which is part of the official [Github API V3](https://developer.github.com/v3/issues/labels/#create-a-label).

As @omgjlk suggested, I've just implemented `create_label` + the read methods (`label()` and `labels()`). If this looks fine I can submit another PR with `update()` (or just add it to this one).

##### Important Note
To read/create label `description`s, a special `Accept` header should be passed (`application/vnd.github.symmetra-preview+json`, [see docs for details](https://developer.github.com/v3/issues/labels/#create-a-label)). So I had to modify slightly the `Session.request` method to accept headers as kwargs.

##### About Tests
I added the corresponding test with description but I can't add new cassettes for integration tests (I don't have the auth token 😅). I've tried it all with a repo of my own and everything is working. You can [see it here](https://github.com/santiagobasulto/delete-testing-github3-integration/labels).