### PR TITLE
Do not use --pre for installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Installation
 
 ::
 
-    $ pip install --pre github3.py
+    $ pip install github3.py
 
 Dependencies
 ------------


### PR DESCRIPTION
Seems that the current latest release is a stable one.

Because the default branch is `develop`, someone navigating the repo for instructions will also see this.

For a better release cycle: no need to use the pre-release command switches.