### PR TITLE
Fix logo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 .. image::
-    https://raw.github.com/sigmavirus24/github3.py/develop/docs/img/gh3-logo.png
+    https://raw.github.com/sigmavirus24/github3.py/master/docs/img/gh3-logo.png
 
 github3.py is a comprehensive, actively developed and extraordinarily stable 
 wrapper around the GitHub API (v3).


### PR DESCRIPTION
Changing the default branch from `develop` to `master` inadvertently
broke the logo link in the README.