### PR TITLE
Use API url instead of hard-coding GitHub url

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -168,3 +168,5 @@ Contributors
 - Taylor Edmiston (@tedmiston)
 
 - Jenny Li (@imjennyli)
+
+- Chandan Singh (@cs-shadow)

--- a/src/github3/models.py
+++ b/src/github3/models.py
@@ -259,7 +259,7 @@ class GitHubCore(object):
 
         :returns: int
         """
-        json = self._json(self._get(self._github_url + '/rate_limit'), 200)
+        json = self._json(self._get(self._build_url('rate_limit')), 200)
         core = json.get('resources', {}).get(self._ratelimit_resource, {})
         self._remaining = core.get('remaining', 0)
         return self._remaining

--- a/src/github3/orgs.py
+++ b/src/github3/orgs.py
@@ -963,7 +963,7 @@ class _Organization(models.GitHubCore):
         :rtype:
             :class:`~github3.projects.Project`
         """
-        url = self._build_url('projects', id, base_url=self._github_url)
+        url = self._build_url('projects', id)
         json = self._json(self._get(url, headers=Project.CUSTOM_HEADERS), 200)
         return self._instance_or_null(Project, json)
 

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -1980,7 +1980,7 @@ class _Repository(models.GitHubCore):
         :rtype:
             :class:`~github3.projects.Project`
         """
-        url = self._build_url('projects', id, base_url=self._github_url)
+        url = self._build_url('projects', id)
         json = self._json(self._get(
             url, headers=projects.Project.CUSTOM_HEADERS), 200)
         return self._instance_or_null(projects.Project, json)


### PR DESCRIPTION
In three places, we incorrectly hardcode `self._github_url` instead of
using `self._api`. This causes the library to break when working with a
GitHub Enterprise instance.