### PR TITLE
Fixed typo in GitHub example for creating a new repo

### DIFF
--- a/docs/source/examples/github.rst
+++ b/docs/source/examples/github.rst
@@ -116,7 +116,7 @@ Creating a new repository
 
     r = None
     if repo.get('name'):
-        r = g.create_repo(repo.pop('name'), **repo)
+        r = g.create_repository(repo.pop('name'), **repo)
 
     if r:
         print("Created {0} successfully.".format(r.name))


### PR DESCRIPTION
Changed g.create_repo to g.create_repository