### PR TITLE
Allow user to set up merge title

### DIFF
--- a/src/github3/pulls.py
+++ b/src/github3/pulls.py
@@ -477,8 +477,14 @@ class _PullRequest(models.GitHubCore):
         return self._iter(int(number), url, IssueComment, etag=etag)
 
     @requires_auth
-    def merge(self, commit_message=None, sha=None, merge_method='merge'):
+    def merge(self, commit_message=None, sha=None, merge_method='merge',
+              commit_title=None):
         """Merge this pull request.
+
+        .. versionchanged:: 1.3.0
+
+            The ``commit_title`` parameter has been added to allow users to
+            set the merge commit title.
 
         .. versionchanged:: 1.0.0
 
@@ -487,6 +493,8 @@ class _PullRequest(models.GitHubCore):
 
         :param str commit_message:
             (optional), message to be used for the merge commit
+        :param str commit_title:
+            (optional), message to be used for the merge commit title
         :param str sha:
             (optional), SHA that pull request head must match to merge.
         :param str merge_method: (optional), Change the merge method.
@@ -502,6 +510,8 @@ class _PullRequest(models.GitHubCore):
             parameters['sha'] = sha
         if commit_message is not None:
             parameters['commit_message'] = commit_message
+        if commit_title is not None:
+            parameters['commit_title'] = commit_title
         url = self._build_url('merge', base_url=self._api)
         json = self._json(self._put(url, data=dumps(parameters)), 200)
         if not json:

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -139,6 +139,15 @@ class TestPullRequest(helper.UnitHelper):
             data={"merge_method": "squash", "commit_message": "commit message"}
         )
 
+    def test_merge_with_custom_title(self):
+        """Show that user can merge a Pull Request with custom commit title"""
+        self.instance.merge(commit_title='commit title')
+
+        self.put_called_with(
+            url_for('merge'),
+            data={"merge_method": "merge", "commit_title": "commit title"}
+        )
+
     def test_patch(self):
         """Show that a user can fetch the patch from a Pull Request."""
         self.instance.patch()


### PR DESCRIPTION
Github allows to setup custom title for commit that is used to merge
pull requests.