### PR TITLE
Set timeout on HTTP requests

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -174,3 +174,5 @@ Contributors
 - Raphael Vogel (@RaphaelVogel)
 
 - Andreas Burger (@AndreasBurger)
+
+- James E. Blair (@jeblair)

--- a/docs/source/api-reference/github.rst
+++ b/docs/source/api-reference/github.rst
@@ -34,3 +34,9 @@ GitHubStatus Object
 
 .. autoclass:: github3.github.GitHubStatus
     :members:
+
+
+GitHubSession Object
+====================
+
+.. autoclass:: github3.session.GitHubSession

--- a/tests/unit/test_github_session.py
+++ b/tests/unit/test_github_session.py
@@ -30,6 +30,37 @@ class TestGitHubSession:
         assert "User-Agent" in s.headers
         assert s.headers["User-Agent"].startswith("github3.py/")
 
+    @mock.patch.object(requests.Session, 'request')
+    def test_default_timeout(self, request_mock):
+        """Test that default timeout values are used"""
+        response = mock.Mock()
+        response.configure_mock(status_code=200, headers={})
+        request_mock.return_value = response
+        s = self.build_session()
+        r = s.get("http://example.com")
+        assert r is response
+        request_mock.assert_called_once_with(
+            "GET", "http://example.com", allow_redirects=True,
+            timeout=(4, 1)
+        )
+
+    @mock.patch.object(requests.Session, 'request')
+    def test_custom_timeout(self, request_mock):
+        """Test that custom timeout values are used"""
+        response = mock.Mock()
+        response.configure_mock(status_code=200, headers={})
+        request_mock.return_value = response
+        s = session.GitHubSession(
+            default_connect_timeout=300,
+            default_read_timeout=400
+        )
+        r = s.get("http://example.com")
+        assert r is response
+        request_mock.assert_called_once_with(
+            "GET", "http://example.com", allow_redirects=True,
+            timeout=(300, 400)
+        )
+
     def test_build_url(self):
         """Test that GitHubSessions build basic URLs"""
         s = self.build_session()
@@ -117,7 +148,8 @@ class TestGitHubSession:
         r = s.get("http://example.com")
         assert r is response
         request_mock.assert_called_once_with(
-            "GET", "http://example.com", allow_redirects=True
+            "GET", "http://example.com", allow_redirects=True,
+            timeout=(4, 1)
         )
 
     @mock.patch.object(requests.Session, "request")


### PR DESCRIPTION
The requests documentation[0] recommends always setting a timeout for requests in order to avoid indefinite hangs.  This can happen if the remote side is unresponsive, or if a network error causes a FIN or RST packet never to arrive.  We have seen this in production against the public GitHub.

This sets a default timeout of 300 seconds for all HTTP requests. The default can be overridden in a parameter to the GitHub constructor.

Because the unit tests assert that the request method is called with specific parameters, we can easily verify that the timeout is passed all the way to the requests library, however, since several hundred tests all do this independently by calling assert_called_once_with(), we will need to update them all to add a timeout argument.  I think that's the right thing to do (since that will now become the typical behavior), but it's a lot of churn.  Therefore, the second commit in this PR only modifies a single test for illustration, so that we can discuss this approach before doing all that work.

[0] http://docs.python-requests.org/en/master/user/quickstart/#timeouts
