### PR TITLE
Fix potential infinite recursion in __getattr__

### DIFF
--- a/src/github3/models.py
+++ b/src/github3/models.py
@@ -54,9 +54,8 @@ class GitHubCore(object):
 
     def __getattr__(self, attribute):
         """Proxy access to stored JSON."""
-        if attribute == '_json_data':
-            raise AttributeError(attribute)
-        if attribute not in self._json_data:
+        json_data = object.__getattr__(self, '_json_data')
+        if attribute not in json_data:
             raise AttributeError(attribute)
         value = self._json_data.get(attribute)
         setattr(self, attribute, value)

--- a/src/github3/models.py
+++ b/src/github3/models.py
@@ -54,6 +54,8 @@ class GitHubCore(object):
 
     def __getattr__(self, attribute):
         """Proxy access to stored JSON."""
+        if attribute == '_json_data':
+            raise AttributeError(attribute)
         if attribute not in self._json_data:
             raise AttributeError(attribute)
         value = self._json_data.get(attribute)

--- a/src/github3/models.py
+++ b/src/github3/models.py
@@ -54,8 +54,7 @@ class GitHubCore(object):
 
     def __getattr__(self, attribute):
         """Proxy access to stored JSON."""
-        json_data = super(GitHubCore, self).__getattr__(self, '_json_data')
-        if attribute not in json_data:
+        if attribute == '_json_data' or attribute not in self._json_data:
             raise AttributeError(attribute)
         value = self._json_data.get(attribute)
         setattr(self, attribute, value)

--- a/src/github3/models.py
+++ b/src/github3/models.py
@@ -54,7 +54,7 @@ class GitHubCore(object):
 
     def __getattr__(self, attribute):
         """Proxy access to stored JSON."""
-        json_data = object.__getattr__(self, '_json_data')
+        json_data = super(GitHubCore, self).__getattr__(self, '_json_data')
         if attribute not in json_data:
             raise AttributeError(attribute)
         value = self._json_data.get(attribute)


### PR DESCRIPTION
When copying an instance of `GitHubCore`, it will cause infinite recursion.
For more info, see the following blog:
https://nedbatchelder.com/blog/201010/surprising_getattr_recursion.html