### PR TITLE
Add support for Draft PR status in responses

### DIFF
--- a/src/github3/checks.py
+++ b/src/github3/checks.py
@@ -58,7 +58,10 @@ class CheckPullRequest(models.GitHubCore):
         """
         from . import pulls
 
-        json = self._json(self._get(self.url), 200)
+        json = self._json(
+            self._get(self.url, headers=pulls.PULLS_PREVIEW_HEADERS),
+            200,
+        )
         return self._instance_or_null(pulls.PullRequest, json)
 
     refresh = to_pull

--- a/src/github3/events.py
+++ b/src/github3/events.py
@@ -161,7 +161,10 @@ class EventPullRequest(models.GitHubCore):
         """
         from . import pulls
 
-        json = self._json(self._get(self.url), 200)
+        json = self._json(
+            self._get(self.url, headers=pulls.PULLS_PREVIEW_HEADERS),
+            200,
+        )
         return self._instance_or_null(pulls.PullRequest, json)
 
     refresh = to_pull

--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -1837,7 +1837,10 @@ class GitHub(models.GitHubCore):
             url = self._build_url(
                 "repos", owner, repository, "pulls", str(number)
             )
-            json = self._json(self._get(url), 200)
+            json = self._json(
+                self._get(url, headers=pulls.PULLS_PREVIEW_HEADERS),
+                200,
+            )
         return self._instance_or_null(pulls.PullRequest, json)
 
     def rate_limit(self):

--- a/src/github3/issues/issue.py
+++ b/src/github3/issues/issue.py
@@ -344,7 +344,13 @@ class _Issue(models.GitHubCore):
         if self.pull_request_urls is not None:
             pull_request_url = self.pull_request_urls.get("url")
         if pull_request_url:
-            json = self._json(self._get(pull_request_url), 200)
+            json = self._json(
+                self._get(
+                    pull_request_url,
+                    headers=pulls.PULLS_PREVIEW_HEADERS,
+                    ),
+                200,
+            )
         return self._instance_or_null(pulls.PullRequest, json)
 
     @requires_auth

--- a/src/github3/projects.py
+++ b/src/github3/projects.py
@@ -558,7 +558,8 @@ class ProjectCard(models.GitHubCore):
         parsed = self._uri_parse(self.content_url)
         _, owner, repository, _, number = parsed.path[1:].split("/", 5)
         resp = self._get(
-            self._build_url("repos", owner, repository, "pulls", number)
+            self._build_url("repos", owner, repository, "pulls", number),
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
         json = self._json(resp, 200)
         return self._instance_or_null(pulls.PullRequest, json)

--- a/src/github3/pulls.py
+++ b/src/github3/pulls.py
@@ -826,7 +826,7 @@ class ShortPullRequest(_PullRequest):
 
             Draft status is only available for repositories with GitHub Free
             and GitHubPro, and in public and private repositories with
-            GitHub Team, GitHub Enterprise CLoud, and GitHub Enterprise
+            GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise
             Server. Unless specific Draft state is provided by GitHub API
             we will set the attribute to to ``False``.
 

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -117,7 +117,14 @@ class _Repository(models.GitHubCore):
         json = None
         if data:
             url = self._build_url("pulls", base_url=self._api)
-            json = self._json(self._post(url, data=data), 201)
+            json = self._json(
+                self._post(
+                    url,
+                    data=data,
+                    headers=pulls.PULLS_PREVIEW_HEADERS,
+                ),
+                201,
+            )
         return self._instance_or_null(pulls.ShortPullRequest, json)
 
     @decorators.requires_auth
@@ -2349,7 +2356,10 @@ class _Repository(models.GitHubCore):
         json = None
         if int(number) > 0:
             url = self._build_url("pulls", str(number), base_url=self._api)
-            json = self._json(self._get(url), 200)
+            json = self._json(
+                self._get(url, headers=pulls.PULLS_PREVIEW_HEADERS),
+                200,
+            )
         return self._instance_or_null(pulls.PullRequest, json)
 
     def pull_requests(
@@ -2408,7 +2418,12 @@ class _Repository(models.GitHubCore):
         params.update(head=head, base=base, sort=sort, direction=direction)
         self._remove_none(params)
         return self._iter(
-            int(number), url, pulls.ShortPullRequest, params, etag
+            int(number),
+            url,
+            pulls.ShortPullRequest,
+            params,
+            etag,
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
     def readme(self):

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -1,6 +1,6 @@
 import pytest
 
-from github3 import GitHubEnterprise, GitHubError
+from github3 import GitHubEnterprise, GitHubError, pulls
 from github3.github import GitHub, GitHubStatus
 from github3.projects import Project
 
@@ -540,7 +540,8 @@ class TestGitHub(helper.UnitHelper):
         )
 
         self.session.get.assert_called_once_with(
-            url_for("repos/octocat/hello-world/pulls/1")
+            url_for("repos/octocat/hello-world/pulls/1"),
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
     def test_pull_request_negative_id(self):

--- a/tests/unit/test_issues_issue.py
+++ b/tests/unit/test_issues_issue.py
@@ -4,6 +4,7 @@ import github3
 import dateutil.parser
 import mock
 
+from github3 import pulls
 from github3.issues.label import Label
 from github3.issues import Issue
 from . import helper
@@ -270,7 +271,8 @@ class TestIssue(helper.UnitHelper):
         self.instance.pull_request()
 
         self.session.get.assert_called_once_with(
-            self.instance.pull_request_urls["url"]
+            self.instance.pull_request_urls["url"],
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
     def test_pull_request_without_urls(self):

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -8,6 +8,7 @@ from github3 import GitHubError
 from github3 import exceptions
 from github3 import issues
 from github3 import projects
+from github3 import pulls
 
 
 get_project_example_data = helper.create_example_data_helper(
@@ -297,7 +298,8 @@ class TestProjectCard(helper.UnitHelper):
 
         self.session.get.assert_called_once_with(
             "https://api.github.com/repos/api-playground/projects-test/"
-            "pulls/3"
+            "pulls/3",
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
 

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -40,6 +40,7 @@ class TestPullRequest(helper.UnitHelper):
                 "body": self.instance.body,
                 "state": "closed",
             },
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
     def test_create_comment(self):
@@ -70,7 +71,9 @@ class TestPullRequest(helper.UnitHelper):
         self.instance.create_review_requests(reviewers=["sigmavirus24"])
 
         self.session.post.assert_called_once_with(
-            url_for("requested_reviewers"), '{"reviewers": ["sigmavirus24"]}'
+            url_for("requested_reviewers"),
+            '{"reviewers": ["sigmavirus24"]}',
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
     def test_create_review(self):
@@ -165,6 +168,7 @@ class TestPullRequest(helper.UnitHelper):
                 "body": self.instance.body,
                 "state": "open",
             },
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
     def test_review_requests(self):
@@ -186,6 +190,7 @@ class TestPullRequest(helper.UnitHelper):
                 "body": "my new body",
                 "state": "open",
             },
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
     def test_attributes(self):

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -4,7 +4,7 @@ import mock
 import pytest
 
 from base64 import b64encode
-from github3 import GitHubError
+from github3 import GitHubError, pulls
 from github3.exceptions import GitHubException
 from github3.repos.comment import RepoComment
 from github3.repos.commit import RepoCommit
@@ -324,7 +324,11 @@ class TestRepository(helper.UnitHelper):
         """Verify the request for creating a pull request."""
         data = {"title": "foo", "base": "master", "head": "feature_branch"}
         self.instance._create_pull(data)
-        self.post_called_with(url_for("pulls"), data=data)
+        self.post_called_with(
+            url_for("pulls"),
+            data=data,
+            headers=pulls.PULLS_PREVIEW_HEADERS,
+        )
 
     def test_create_pull(self):
         """Verify the request for creating a pull request."""
@@ -804,7 +808,10 @@ class TestRepository(helper.UnitHelper):
     def test_pull_request(self):
         """Verify the request for retrieving a pull request."""
         self.instance.pull_request(1)
-        self.session.get.assert_called_once_with(url_for("pulls/1"))
+        self.session.get.assert_called_once_with(
+            url_for("pulls/1"),
+            headers=pulls.PULLS_PREVIEW_HEADERS,
+        )
 
     def test_pull_request_required_number(self):
         """Verify the request for retrieving a pull request."""
@@ -1273,7 +1280,7 @@ class TestRepositoryIterator(helper.UnitIteratorHelper):
         self.session.get.assert_called_once_with(
             url_for("pulls"),
             params={"per_page": 100, "sort": "created", "direction": "desc"},
-            headers={},
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
     def test_pull_requests_ignore_invalid_state(self):
@@ -1284,7 +1291,7 @@ class TestRepositoryIterator(helper.UnitIteratorHelper):
         self.session.get.assert_called_once_with(
             url_for("pulls"),
             params={"per_page": 100, "sort": "created", "direction": "desc"},
-            headers={},
+            headers=pulls.PULLS_PREVIEW_HEADERS,
         )
 
     def test_refs(self):


### PR DESCRIPTION
This adds response data support for the `draft` status of a pull
request. This was recently
[added](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
to the platform and API. A PullRequest can be marked as a `draft` which
will prevent merging and delay triggering automatic pull request reviews
from `CODEOWNERS`.

Support for receiving the data is still in preview so new headers have
to be littered throughout the codebase.

Resolves: #926