### PR TITLE
Docs: Update contents to file_contents

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -178,3 +178,5 @@ Contributors
 - James E. Blair (@jeblair)
 
 - Simon Westphahl (@westphahl)
+
+- Steven Nyman (@stevennyman)

--- a/docs/source/examples/github.rst
+++ b/docs/source/examples/github.rst
@@ -126,7 +126,7 @@ Create a commit to change an existing file
 
 ::
 
-    repo.contents('/README.md').update('commit message', 'file content'.encode('utf-8'))
+    repo.file_contents('/README.md').update('commit message', 'file content'.encode('utf-8'))
 
 Follow another user on GitHub
 -----------------------------


### PR DESCRIPTION
This is an update to outdated syntax in the docs.