### PR TITLE
.travis.yml: The sudo tag is now deprecated in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,19 +25,16 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+      dist: xenial    # required for Python >= 3.7
     - python: nightly
       env: TOXENV=py38
-      dist: xenial    # required for Python 3.8 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.8 (travis-ci/travis-ci#9069)
+      dist: xenial    # required for Python >= 3.7
     - python: pypy
       env: TOXENV=pypy
     - python: 2.7
       env: TOXENV=py27-flake8
     - python: 3.7
-      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+      dist: xenial    # required for Python >= 3.7
       env: TOXENV=py37-flake8
     - env: TOXENV=docstrings
     - env: TOXENV=notebooks


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo:__ in your __.travis.yml__, we recommend removing that configuration_"