### PR TITLE
Don't expect commit_id for PullReview

### DIFF
--- a/src/github3/pulls.py
+++ b/src/github3/pulls.py
@@ -926,6 +926,12 @@ class PullReview(models.GitHubCore):
 
         The SHA of the commit that the review was left on.
 
+        .. note::
+
+            It is possible for the attribute to be set to ``None``, if the
+            review references a commit that is no longer available in the pull
+            request branch, such as after a force push.
+
     .. attribute:: html_url
 
         .. versionadded:: 1.0.0
@@ -958,7 +964,9 @@ class PullReview(models.GitHubCore):
         self.body = review["body"]
         self.body_html = review["body_html"]
         self.body_text = review["body_text"]
-        self.commit_id = review["commit_id"]
+        # NOTE(pabelanger): In some cases, commit_id could be missing on a
+        # PullReview.
+        self.commit_id = review.get("commit_id", None)
         self.html_url = review["html_url"]
         self.user = users.ShortUser(review["user"], self)
         self.state = review["state"]


### PR DESCRIPTION
In some cases, a PullReview may not have a commit_id (I am not sure why
that is). In this case, we should not always expect it to be there.

  2019-05-30 21:20:25,678 ERROR zuul.GithubEventConnector: Exception moving GitHub event:
  Traceback (most recent call last):
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/github3/models.py", line 48, in __init__
      self._update_attributes(json)
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/github3/pulls.py", line 961, in _update_attributes
      self.commit_id = review["commit_id"]
  KeyError: 'commit_id'

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/zuul/driver/github/githubconnection.py", line 484, in run
      GithubEventProcessor(self, data).run()
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/zuul/driver/github/githubconnection.py", line 218, in run
      self._handle_event()
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/zuul/driver/github/githubconnection.py", line 265, in _handle_event
      refresh=True)
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/zuul/driver/github/githubconnection.py", line 903, in _getChange
      self._updateChange(change)
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/zuul/driver/github/githubconnection.py", line 1008, in _updateChange
      change.number)
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/zuul/driver/github/githubconnection.py", line 1246, in getPullReviews
      revs = [review.as_dict() for review in pr_obj.reviews()]
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/zuul/driver/github/githubconnection.py", line 1246, in <listcomp>
      revs = [review.as_dict() for review in pr_obj.reviews()]
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/github3/structs.py", line 122, in __iter__
      yield cls(i)
    File "/opt/venv/zuul-3.8.1/lib/python3.6/site-packages/github3/models.py", line 50, in __init__
      raise exceptions.IncompleteResponse(json, kerr)
  github3.exceptions.IncompleteResponse: None The library was expecting more data in the response (KeyError('commit_id',)). Either GitHub modified it's response body, or your token is not prop
  erly scoped to retrieve this information.

  https://api.github.com/repos/ansible/ansible/pulls/45469/reviews

Signed-off-by: Paul Belanger <pabelanger@redhat.com>