### PR TITLE
Add all GitHubSession attributes to __attrs__. #946

### DIFF
--- a/src/github3/session.py
+++ b/src/github3/session.py
@@ -91,6 +91,9 @@ class GitHubSession(requests.Session):
     __attrs__ = requests.Session.__attrs__ + [
         "base_url",
         "two_factor_auth_cb",
+        "default_connect_timeout",
+        "default_read_timeout",
+        "request_counter",
     ]
 
     def __init__(self, default_connect_timeout=4, default_read_timeout=10):


### PR DESCRIPTION
GitHubSession objects can't be properly copied without the `__attrs__`
list being correct.  The requests Session object implements `__getstate__`
using the `__attrs__` list.