### PR TITLE
Fix potential infinite recursion in __getattr__

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -182,3 +182,5 @@ Contributors
 - Steven Nyman (@stevennyman)
 
 - Tigran Tchougourian (@NargiT)
+
+- Samuel Mendes (@smendes)

--- a/src/github3/models.py
+++ b/src/github3/models.py
@@ -54,9 +54,10 @@ class GitHubCore(object):
 
     def __getattr__(self, attribute):
         """Proxy access to stored JSON."""
-        if attribute not in self._json_data:
+        _json_data = object.__getattribute__(self, "_json_data")
+        if attribute not in _json_data:
             raise AttributeError(attribute)
-        value = self._json_data.get(attribute)
+        value = _json_data[attribute]
         setattr(self, attribute, value)
         return value
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import requests
 
+from copy import copy
 from datetime import datetime, timedelta
 from github3 import exceptions, GitHubError
 from github3.models import GitHubCore
@@ -205,6 +206,10 @@ class TestGitHubCore(helper.UnitHelper):
     def test_strptime_time_str_required(self):
         """Verify that method converts ISO 8601 formatted string."""
         assert self.instance._strptime("") is None
+
+    def test_can_be_copied(self):
+        """Verify that a GithubCore object can be copied."""
+        assert copy(self.instance) is not None
 
 
 class TestGitHubCoreIssue672(helper.UnitHelper):


### PR DESCRIPTION
I ran into an issue causing the infinite recursion, I saw that PR https://github.com/sigmavirus24/github3.py/pull/912 was already open for it and the discussion that goes with it. But that PR hasn't changed in a while and didn't include a test for this bug.

I think this bug only happens for Python 3+ (I can at least confirm it with 3.7), when calling `copy` on a `GithubCore` instance a call to `foo.__getattr__("_json_data")` is made while `__init__` wasn't called. Causing `self._json_data` [here](https://github.com/sigmavirus24/github3.py/blob/master/src/github3/models.py#L57) to call again `self.__getattr__("_json_data")` and so on.

By using `object.__getattribute__(self, "_json_data")` instead we make sure that we won't fallback on `__getattr__` and avoid this infinite loop.