### PR TITLE
repos: Allow to create draft pull requests

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -186,3 +186,5 @@ Contributors
 - Samuel Mendes (@smendes)
 
 - Dimitri Merejkowsky (@dmerejkowsky)
+
+- Damien Baty (@dbaty)

--- a/src/github3/pulls.py
+++ b/src/github3/pulls.py
@@ -15,6 +15,11 @@ from .issues import Issue
 from .issues.comment import IssueComment
 
 
+PULLS_PREVIEW_HEADERS = {
+    "Accept": "application/vnd.github.shadow-cat-preview",
+}
+
+
 class PullDestination(models.GitHubCore):
     """The object that represents a pull request destination.
 

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -117,7 +117,7 @@ class _Repository(models.GitHubCore):
         json = None
         if data:
             url = self._build_url("pulls", base_url=self._api)
-            json = self._json(self._post(url, data=data), 201)
+            json = self._json(self._post(url, data=data, headers=pulls.PULLS_PREVIEW_HEADERS), 201)
         return self._instance_or_null(pulls.ShortPullRequest, json)
 
     @decorators.requires_auth
@@ -1097,7 +1097,7 @@ class _Repository(models.GitHubCore):
         return self._instance_or_null(projects.Project, json)
 
     @decorators.requires_auth
-    def create_pull(self, title, base, head, body=None):
+    def create_pull(self, title, base, head, body=None, draft=False):
         """Create a pull request of ``head`` onto ``base`` branch in this repo.
 
         :param str title:
@@ -1108,16 +1108,18 @@ class _Repository(models.GitHubCore):
             (required), e.g., 'username:branch'
         :param str body:
             (optional), markdown formatted description
+        :param draft boolean:
+            (optional), whether to create a draft pull request
         :returns:
             the created pull request
         :rtype:
             :class:`~github3.pulls.ShortPullRequest`
         """
-        data = {"title": title, "body": body, "base": base, "head": head}
+        data = {"title": title, "body": body, "base": base, "head": head, "draft": draft}
         return self._create_pull(data)
 
     @decorators.requires_auth
-    def create_pull_from_issue(self, issue, base, head):
+    def create_pull_from_issue(self, issue, base, head, draft=False):
         """Create a pull request from issue #``issue``.
 
         :param int issue:
@@ -1126,13 +1128,15 @@ class _Repository(models.GitHubCore):
             (required), e.g., 'master'
         :param str head:
             (required), e.g., 'username:branch'
+        :param draft boolean:
+            (optional), whether to create a draft pull request
         :returns:
             the created pull request
         :rtype:
             :class:`~github3.pulls.ShortPullRequest`
         """
         if int(issue) > 0:
-            data = {"issue": issue, "base": base, "head": head}
+            data = {"issue": issue, "base": base, "head": head, "draft": draft}
             return self._create_pull(data)
         return None
 

--- a/tests/integration/test_repos_repo.py
+++ b/tests/integration/test_repos_repo.py
@@ -454,6 +454,28 @@ class TestRepository(helper.IntegrationHelper):
 
         assert isinstance(pull_request, github3.pulls.ShortPullRequest)
 
+    def test_create_pull_draft(self):
+        """Test the ability to create a draft pull request on a repository."""
+        self.token_login()
+        cassette_name = self.cassette_name("create_pull_draft")
+        with self.recorder.use_cassette(cassette_name):
+            original_repository = self.gh.repository(
+                "github3py", "github3.py"
+            )
+            repository = original_repository.create_fork(
+                organization="testgh3py"
+            )
+            pull_request = repository.create_pull(
+                title="Update forked repo",
+                base="master",
+                head="testgh3py:develop",
+                body="Testing the ability to create a draft pull request",
+                draft=True,
+            )
+            repository.delete()
+
+        assert isinstance(pull_request, github3.pulls.ShortPullRequest)
+
     def test_create_pull_from_issue(self):
         """Verify creation of a pull request from an issue."""
         self.token_login()

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -322,9 +322,13 @@ class TestRepository(helper.UnitHelper):
 
     def test_create_pull_private(self):
         """Verify the request for creating a pull request."""
-        data = {"title": "foo", "base": "master", "head": "feature_branch"}
+        data = {"title": "foo", "base": "master", "head": "feature_branch", "draft": True}
         self.instance._create_pull(data)
-        self.post_called_with(url_for("pulls"), data=data)
+        self.post_called_with(
+            url_for("pulls"),
+            data=data,
+            headers={'Accept': 'application/vnd.github.shadow-cat-preview'},
+        )
 
     def test_create_pull(self):
         """Verify the request for creating a pull request."""
@@ -333,6 +337,7 @@ class TestRepository(helper.UnitHelper):
             "base": "master",
             "head": "feature_branch",
             "body": "body",
+            "draft": True,
         }
         with helper.mock.patch.object(Repository, "_create_pull") as pull:
             self.instance.create_pull(**data)
@@ -341,7 +346,7 @@ class TestRepository(helper.UnitHelper):
     def test_create_pull_from_issue(self):
         """Verify the request for creating a pull request from an issue."""
         with helper.mock.patch.object(Repository, "_create_pull") as pull:
-            data = {"issue": 1, "base": "master", "head": "feature_branch"}
+            data = {"issue": 1, "base": "master", "head": "feature_branch", "draft": True}
             self.instance.create_pull_from_issue(**data)
             pull.assert_called_once_with(data)
 


### PR DESCRIPTION
`Repository.create_pull` and `create_pull_from_issue` now take an
optional `draft` argument.

---

This pull request adds support to *create* draft pull requests. There is already another pull request (#927) to *read* the draft status when fetching pull requests. These two pull requests are independent and could be merged separately. I just reused the constant `pulls.PULLS_PREVIEW_HEADERS` that is added by #927.

Integration tests fail: some cassettes should be updated to include the `draft` parameter that we now send. It's not clear to me how to do that properly. I tried to add `record='all'` to calls to `use_cassette()` in those tests, but I get a `403 Must have admin rights to Repository.` error on the call to `original_repository.create_fork(organization="testgh3py"). Which I don't find surprising, of course. :) What's the way forward, here?