### PR TITLE
Remove headers dict

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -188,3 +188,5 @@ Contributors
 - Dimitri Merejkowsky (@dmerejkowsky)
 
 - Erico Fusco (@ericofusco)
+
+- Ben Jefferies (@benjefferies)

--- a/src/github3/repos/branch.py
+++ b/src/github3/repos/branch.py
@@ -407,7 +407,7 @@ class ProtectionEnforceAdmins(models.GitHubCore):
     def enable(self):
         """Enable Admin enforcement for protected branch."""
         resp = self._post(
-            self._api, headers=BranchProtection.PREVIEW_HEADERS_MAP
+            self._api
         )
         return self._boolean(resp, 200, 404)
 
@@ -415,7 +415,7 @@ class ProtectionEnforceAdmins(models.GitHubCore):
     def disable(self):
         """Disable Admin enforcement for protected branch."""
         resp = self._delete(
-            self._api, headers=BranchProtection.PREVIEW_HEADERS_MAP
+            self._api
         )
         return self._boolean(resp, 204, 404)
 

--- a/tests/unit/test_repos_branch_protection.py
+++ b/tests/unit/test_repos_branch_protection.py
@@ -34,7 +34,6 @@ class TestProtectionEnforceAdmins(helper.UnitHelper):
         self.instance.enable()
         self.post_called_with(
             enforce_admins_url_for(),
-            headers=BranchProtection.PREVIEW_HEADERS_MAP,
         )
 
     def test_disable(self):
@@ -42,7 +41,6 @@ class TestProtectionEnforceAdmins(helper.UnitHelper):
         self.instance.disable()
         self.delete_called_with(
             enforce_admins_url_for(),
-            headers=BranchProtection.PREVIEW_HEADERS_MAP,
         )
 
 


### PR DESCRIPTION
Remove dict as it's in the wrong format and was causing the error

```
Traceback (most recent call last):
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 2060, in <module>
    main()
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 2054, in main
    globals = debugger.run(setup['file'], None, None, is_module)
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 1405, in run
    return self._exec(is_module, entry_point_fn, module_name, file, globals, locals)
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 1412, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/benjefferies/source/github/benjefferies/branch-protection-bot/run.py", line 35, in <module>
    toggle_enforce_admin(options.access_token, options.owner, options.repo, options.branch)
  File "/Users/benjefferies/source/github/benjefferies/branch-protection-bot/run.py", line 24, in toggle_enforce_admin
    protection.enforce_admins.enable()
  File "/Users/benjefferies/.virtualenvs/branch-protection-bot-va0BIfgL/lib/python3.6/site-packages/github3/decorators.py", line 31, in auth_wrapper
    return func(self, *args, **kwargs)
  File "/Users/benjefferies/.virtualenvs/branch-protection-bot-va0BIfgL/lib/python3.6/site-packages/github3/repos/branch.py", line 410, in enable
    self._api, headers=BranchProtection.PREVIEW_HEADERS_MAP
  File "/Users/benjefferies/.virtualenvs/branch-protection-bot-va0BIfgL/lib/python3.6/site-packages/github3/models.py", line 222, in _post
    return self._request("post", url, data, **kwargs)
  File "/Users/benjefferies/.virtualenvs/branch-protection-bot-va0BIfgL/lib/python3.6/site-packages/github3/models.py", line 204, in _request
    raise exceptions.TransportError(exc)
github3.exceptions.TransportError: <class 'requests.exceptions.InvalidHeader'>: An error occurred while making a request to GitHub: Value for header {required_approving_review_count: {'Accept': 'application/vnd.github.luke-cage-preview+json'}} must be of type str or bytes, not <class 'dict'>

```