### PR TITLE
Drop python 34 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ environment:
       TOXENV: py27
     - PYTHON: "C:\\Python27-x64"
       TOXENV: py27
-    - PYTHON: "C:\\Python34"
-      TOXENV: py34
-    - PYTHON: "C:\\Python34-x64"
-      TOXENV: py34
     - PYTHON: "C:\\Python35"
       TOXENV: py35
     - PYTHON: "C:\\Python35-x64"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,38,py},black,py{27,37}-flake8,doclint,commitlint,docstrings
+envlist = py{27,35,36,37,38,py},black,py{27,37}-flake8,doclint,commitlint,docstrings
 minversion = 3.1.3
 
 [testenv]
@@ -13,7 +13,6 @@ deps =
     betamax>=0.5.1
     betamax_matchers>=0.3.0
     pypy,py27: unittest2
-    py34: pytest>=2.3.5, <4.6.7 ; sys_platform == 'win32'
 commands = py.test {posargs}
 
 [testenv:py27-flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     betamax>=0.5.1
     betamax_matchers>=0.3.0
     pypy,py27: unittest2
+    py34: pytest>=2.3.5, <4.6.7 ; sys_platform == 'win32'
 commands = py.test {posargs}
 
 [testenv:py27-flake8]


### PR DESCRIPTION
We're getting dep issues on python 3.4. This platform is too old to continue support for