### PR TITLE
Clarify the type of the 'owner' attribute on Repository objects

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -190,3 +190,5 @@ Contributors
 - Erico Fusco (@ericofusco)
 
 - Ben Jefferies (@benjefferies)
+
+- Kevin P. Fleming (@kpfleming)

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -3242,7 +3242,8 @@ class ShortRepository(_Repository):
 
     .. attribute:: owner
 
-        The owner of the repository, e.g., ``sigmavirus24``.
+        A :class:`~github3.users.ShortUser` object representing the owner of
+        the repository.
 
     .. attribute:: private
 


### PR DESCRIPTION
Throughout the github3.py API, 'owner' is generally a string object, but
the 'owner' attribute of Repository objects is not, it's a ShortUser object.
This patch updates the documentation to explicitly indicate that so that
developers won't be surprised by the type of the attribute.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>