### PR TITLE
Add python 3.9 and fix python nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,10 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
     - python: nightly
-      env: TOXENV=py38
+      env: TOXENV=py39
     - python: pypy
       env: TOXENV=pypy
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
-    - python: 3.9
-      env: TOXENV=py39
     - python: nightly
       env: TOXENV=py39
     - python: pypy

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
 commands = black -l78 -N src/github3/ tests/
 
 [testenv:notebooks]
-basepython = python3.4
+basepython = python3.6
 deps =
     ipython[notebook]
 commands = python tests/nbtest.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38,py},black,py{27,37}-flake8,doclint,commitlint,docstrings
+envlist = py{27,35,36,37,38,39,py},black,py{27,37}-flake8,doclint,commitlint,docstrings
 minversion = 3.1.3
 
 [testenv]


### PR DESCRIPTION
Nightly is now 3.9 based so tests were failing to find 3.8