### PR TITLE
Fix imports of unittest.mock

### DIFF
--- a/tests/unit/test_issues_issue.py
+++ b/tests/unit/test_issues_issue.py
@@ -2,7 +2,10 @@
 """Unit tests for the Issue class."""
 import github3
 import dateutil.parser
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from github3.issues.label import Label
 from github3.issues import Issue

--- a/tests/unit/test_orgs.py
+++ b/tests/unit/test_orgs.py
@@ -1,5 +1,8 @@
 """Organization unit tests."""
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from github3 import GitHubError

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -1,6 +1,9 @@
 """Unit tests for Repositories."""
 import datetime
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from base64 import b64encode

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,7 +2,10 @@ from datetime import datetime
 from github3.utils import stream_response_to_file, timestamp_parameter
 
 import io
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 import requests
 


### PR DESCRIPTION
Fix all tests to support using unittest.mock over external mock package.
The test suite dependencies already list mock only for py<3.3.