### PR TITLE
Avoid using content from NetRC when using GitHub App API

### DIFF
--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -1399,14 +1399,14 @@ class GitHub(models.GitHubCore):
         # NOTE(sigmavirus24): This JWT token does not need to last very long.
         # Instead of allowing it to stick around for 10 minutes, let's limit
         # it to 30 seconds.
-        headers = apps.create_jwt_headers(
+        auth_handler = apps.create_jwt_handler(
             private_key_pem, app_id, expire_in=30
         )
         url = self._build_url(
             "app", "installations", str(installation_id), "access_tokens"
         )
         with self.session.no_auth():
-            response = self.session.post(url, headers=headers)
+            response = self.session.post(url, auth=auth_handler)
             json = self._json(response, 201)
 
         self.session.app_installation_token_auth(json)


### PR DESCRIPTION
When using the default authentication handler and not overwriting the auth parameter, the netrc file will be read and will overwrite an existing value that was provided using the headers parameter. As the value in the NetRC is wrong a 401 will happen. Using a custom auth handler will ensure the expected token is beeing used. 

Before opening a new issue, please [search][] for a previously filed
issue to ensure you're not creating a duplicate.

**Note** Bug reports without the following will receive requests for these 
details to be provided.

## Version Information

Please provide:

- The version of Python you're using **3.8.5**

- The version of pip you used to install github3.py **20.2.4**

- The version of github3.py, requests, uritemplate, and dateutil installed **1.3.0**

## Minimum Reproducible Example

1. Add an invalid entry for GitHub(-server) to your netrc.
2. Try to authenticate using a GitHub App

## Exception information

Login does not work. When using the debugger you can see the authentication header used by requests. It's the value from NetRC.

<!-- links -->
[search]: https://github.com/sigmavirus24/github3.py/issues?utf8=%E2%9C%93&q=is%3Aissue
