### PR TITLE
Use AppBearerTokenAuth in login_as_app_installation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -200,3 +200,5 @@ Contributors
 - Andrew Hayworth (@ahayworth)
 
 - Dmitry Kiselev (@dmitrykiselev27)
+
+- Adeodato Simó (@dato)


### PR DESCRIPTION
Previously, this method used an Authorization header via `headers`
parameter, instead of an AuthBase instance via `auth` parameter.

But the requests library has this behavior where it will strip the
Authorization header on redirects, and then pick up fresh credentials
from other sources (~/.netrc in particular, if present).

Any AuthBase object, though, is still attached to the request, so this
makes for an incredibly difficult issue to debug: all of github3.py
uses AuthBase to authenticate, except login_as_app_installation. The
latter thus being the only place in which the issue can manifest, when
~/.netrc has an entry for api.github.com. By using AppBearerTokenAuth,
this can no longer happen.