### PR TITLE
Fix gist.history keyerrors

### DIFF
--- a/docs/source/release-notes/2.0.0.rst
+++ b/docs/source/release-notes/2.0.0.rst
@@ -1,4 +1,4 @@
-2.0.0: 2020-01-06
+2.0.0: 2020-01-10
 -----------------
 
 Features Added
@@ -9,6 +9,11 @@ Features Added
 - Update CI/CD to thoroughly test all supported version.
 - Remove compatibility imports for Python 2.
 - Remove dev-dependency for mock.
+
+Bugs Fixed
+``````````
+
+* Key errors on Gist.history.
 
 Removals
 ````````
@@ -56,4 +61,3 @@ Removals
 - ``Organization#add_member`` add ``username`` to ``team``.
 - ``Organization#events`` use ``Organization#public_events``
 - ``Issue#assign`` use ``issues.issue.Issue.add_assignees``
-

--- a/src/github3/gists/history.py
+++ b/src/github3/gists/history.py
@@ -53,11 +53,11 @@ class GistHistory(models.GitHubCore):
         self.url = self._api = history["url"]
         self.version = history["version"]
         self.user = users.ShortUser(history["user"], self)
-        self.change_status = history.get("change_status")
+        self.change_status = history["change_status"]
         self.additions = self.change_status.get("additions")
         self.deletions = self.change_status.get("deletions")
-        self.total = self.change_status.get("total")
-        self.committed_at = self._strptime(history.get("committed_at"))
+        self.total = self.change_status["total"]
+        self.committed_at = self._strptime(history["committed_at"])
 
     def _repr(self) -> str:
         return f"<Gist History [{self.version}]>"

--- a/src/github3/gists/history.py
+++ b/src/github3/gists/history.py
@@ -43,24 +43,24 @@ class GistHistory(models.GitHubCore):
         The number of deletions from the gist compared to the previous
         revision.
 
-    .. attribute:: totoal
+    .. attribute:: total
 
         The total number of changes to the gist compared to the previous
         revision.
     """
 
-    def _update_attributes(self, history):
+    def _update_attributes(self, history) -> None:
         self.url = self._api = history["url"]
         self.version = history["version"]
         self.user = users.ShortUser(history["user"], self)
-        self.change_status = history["change_status"]
-        self.additions = self.change_status["additions"]
-        self.deletions = self.change_status["deletions"]
-        self.total = self.change_status["total"]
-        self.committed_at = self._strptime(history["committed_at"])
+        self.change_status = history.get("change_status")
+        self.additions = self.change_status.get("additions")
+        self.deletions = self.change_status.get("deletions")
+        self.total = self.change_status.get("total")
+        self.committed_at = self._strptime(history.get("committed_at"))
 
-    def _repr(self):
-        return "<Gist History [{0}]>".format(self.version)
+    def _repr(self) -> str:
+        return f"<Gist History [{self.version}]>"
 
     def gist(self):
         """Retrieve the gist at this version.


### PR DESCRIPTION
* Uses get method for responses missing attributes.
* Add some typing to return methods.
* Fix a typo in docstring.
* Add f-string for legibility.
* Add release note.

Closes #1019 