### PR TITLE
Fix issues when updating branch protections

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -204,3 +204,5 @@ Contributors
 - Dmitry Kiselev (@dmitrykiselev27)
 
 - Adeodato Simó (@dato)
+
+- JP Sullivan (@j3p0uk)


### PR DESCRIPTION
In trying to use the library in managing GitHub repositories through simple yaml configuration files I found issues trying to update branch_protections.  I believe that at times the library can use complex models where the slugs are required, as per the reproducer.

If there is something not right about what I am trying to do, then I would welcome suggestions as to the right way to utilise the library for this.  I felt like the objects returned should be

## Version Information

Please provide:

- The version of Python you're using

3.9

- The version of pip you used to install github3.py

21.1

- The version of github3.py, requests, uritemplate, and dateutil installed

github3.py @ file:///workspaces/github3.py (This Pull Request, working tree from master - 9345f86942867c757a4bc0acd8b4b3334364d4e4)
python-dateutil==2.8.1
requests==2.25.1
requests-toolbelt==0.9.1
uritemplate==3.0.1

## Minimum Reproducible Example

Please provide an example of the code that generates the error you're seeing.

```
>>> import github3
>>> github = github3.enterprise_login(url='https://<redacted>/',  token='<redacted>')
>>> repo = github.repository('<redacted>', '< redacted>')
>>> branch = repo.branch('main')
>>> bp = branch.protection()
>>> res = bp.restrictions
>>> bp.update(restrictions=res)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vscode/.local/lib/python3.9/site-packages/github3/decorators.py", line 26, in auth_wrapper
    return func(self, *args, **kwargs)
  File "/home/vscode/.local/lib/python3.9/site-packages/github3/repos/branch.py", line 366, in update
    self._put(self._api, json=edit, headers=headers), 200
  File "/home/vscode/.local/lib/python3.9/site-packages/github3/models.py", line 224, in _put
    return self._request("put", url, **kwargs)
  File "/home/vscode/.local/lib/python3.9/site-packages/github3/models.py", line 195, in _request
    return request_method(*args, **kwargs)
  File "/home/vscode/.local/lib/python3.9/site-packages/requests/sessions.py", line 602, in put
    return self.request('PUT', url, data=data, **kwargs)
  File "/home/vscode/.local/lib/python3.9/site-packages/github3/session.py", line 174, in request
    response = super(GitHubSession, self).request(*args, **kwargs)
  File "/home/vscode/.local/lib/python3.9/site-packages/requests/sessions.py", line 528, in request
    prep = self.prepare_request(req)
  File "/home/vscode/.local/lib/python3.9/site-packages/requests/sessions.py", line 456, in prepare_request
    p.prepare(
  File "/home/vscode/.local/lib/python3.9/site-packages/requests/models.py", line 319, in prepare
    self.prepare_body(data, files, json)
  File "/home/vscode/.local/lib/python3.9/site-packages/requests/models.py", line 469, in prepare_body
    body = complexjson.dumps(json)
  File "/usr/local/lib/python3.9/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type ProtectionRestrictions is not JSON serializable
>>> bp.update(restrictions=res.as_dict())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vscode/.local/lib/python3.9/site-packages/github3/decorators.py", line 26, in auth_wrapper
    return func(self, *args, **kwargs)
  File "/home/vscode/.local/lib/python3.9/site-packages/github3/repos/branch.py", line 358, in update
    json = self._json(
  File "/home/vscode/.local/lib/python3.9/site-packages/github3/models.py", line 155, in _json
    raise exceptions.error_for(response)
github3.exceptions.UnprocessableEntity: 422 Invalid request.

No subschema in "anyOf" matched.
For 'items', {"login"=>"<redacted>", "id"=><redacted>, "node_id"=>"<redacted>", "avatar_url"=>"<redacted>", "gravatar_id"=>"", "url"=>"<redacted>", "html_url"=>"<redacted>", "followers_url"=>"<redacted>/followers", "following_url"=>"<redacted>/following{/other_user}", "gists_url"=>"<redacted>/gists{/gist_id}", "starred_url"=>"<redacted>/starred{/owner}{/repo}", "subscriptions_url"=>"<redacted>/subscriptions", "organizations_url"=>"<redacted>/orgs", "repos_url"=>"<redacted>/repos", "events_url"=>"<redacted>/events{/privacy}", "received_events_url"=>"<redacted>/received_events", "type"=>"User", "site_admin"=>false, "ldap_dn"=>"<redacted>"} is not a string.
Not all subschemas of "allOf" matched.
For 'anyOf/1', {"url"=>"<redacted>/protection/restrictions", "users_url"=>"<redacted>/protection/restrictions/users", "teams_url"=>"<redacted>/protection/restrictions/teams", "apps_url"=>"<redacted>/protection/restrictions/apps", "users"=>[{"login"=>"<redacted>", "id"=><redacted>, "node_id"=>"<redacted>", "avatar_url"=>"<redacted>", "gravatar_id"=>"", "url"=>"<redacted>", "html_url"=>"<redacted>", "followers_url"=>"<redacted>/followers", "following_url"=>"<redacted>/following{/other_user}", "gists_url"=>"<redacted>/gists{/gist_id}", "starred_url"=>"<redacted>/starred{/owner}{/repo}", "subscriptions_url"=>"<redacted>/subscriptions", "organizations_url"=>"<redacted>/orgs", "repos_url"=>"<redacted>/repos", "events_url"=>"<redacted>/events{/privacy}", "received_events_url"=>"<redacted>/received_events", "type"=>"User", "site_admin"=>false, "ldap_dn"=>"<redacted>"}], "teams"=>[], "apps"=>[]} is not a null.
```

## Exception information

What is exceptional about what you're seeing versus what you expected to see.

Update did not work, due to the user/team/app types being the github3.py internal object models and not simple slugs.

<!-- links -->
[search]: https://github.com/sigmavirus24/github3.py/issues?utf8=%E2%9C%93&q=is%3Aissue
