### PR TITLE
Add repositories pagination

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -204,3 +204,5 @@ Contributors
 - Dmitry Kiselev (@dmitrykiselev27)
 
 - Adeodato Simó (@dato)
+
+- Victor Zinchenko (@viktor-zinchenko)

--- a/src/github3/orgs.py
+++ b/src/github3/orgs.py
@@ -990,7 +990,7 @@ class _Organization(models.GitHubCore):
         url = self._build_url("memberships", username, base_url=self._api)
         return self._boolean(self._delete(url), 204, 404)
 
-    def repositories(self, type="", number=-1, etag=None):
+    def repositories(self, type="", number=-1, etag=None, page=None):
         """Iterate over repos for this organization.
 
         :param str type:
@@ -1001,6 +1001,8 @@ class _Organization(models.GitHubCore):
             all available.
         :param str etag:
             (optional), ETag from a previous request to the same endpoint
+        :param int page:
+            (optional), number of page to return
         :returns:
             generator of repositories in this organization
         :rtype:
@@ -1008,6 +1010,11 @@ class _Organization(models.GitHubCore):
         """
         url = self._build_url("repos", base_url=self._api)
         params = {}
+        if page:
+            params["page"] = page
+            if number == -1:
+                # default number of items on page
+                number = 100
         if type in ("all", "public", "member", "private", "forks", "sources"):
             params["type"] = type
         return self._iter(int(number), url, ShortRepository, params, etag)

--- a/tests/unit/test_orgs.py
+++ b/tests/unit/test_orgs.py
@@ -477,6 +477,17 @@ class TestOrganizationIterator(helper.UnitIteratorHelper):
             url_for("repos"), params={"per_page": 100}, headers={}
         )
 
+    def test_repositories_with_page(self):
+        """Show that one can iterate over repositories with parameters."""
+        i = self.instance.repositories(page=10)
+        self.get_next(i)
+
+        self.session.get.assert_called_once_with(
+            url_for("repos"),
+            params={"page": 10, "per_page": 100},
+            headers={},
+        )
+
     def test_respositories_accepts_type(self):
         """Show that one can pass a repository type."""
         i = self.instance.repositories("all")


### PR DESCRIPTION
Tests shown that request to /orgs/{org}/repos endpoint to organization with 1000+ repositories could take more then 1 minute.

So the idea is to add support forpage parameter to the request, to be able to iterate over organization with high number of repositories.