### PR TITLE
Add maintainer_can_modify parameter to create_pull

### DIFF
--- a/docs/bin/lint
+++ b/docs/bin/lint
@@ -1,5 +1,5 @@
 #!/bin/sh
-output="$(find docs/source -name '*.rst' | xargs proselint)"
+output="$(find docs/source -name '*.rst' | grep -v docs/source/examples/octocat.rst | xargs proselint)"
 exit_code=$?
 
 if echo "$output" | grep -qve 'typography' ; then

--- a/docs/source/contributing/testing.rst
+++ b/docs/source/contributing/testing.rst
@@ -229,7 +229,7 @@ started when you write
 .. code:: python
 
     with self.recorder.use_cassette(cassette_name):
-        # ...
+        # …
 
 Everything that talks to GitHub should be written inside of the context
 created by the context manager there. No requests to GitHub should be made

--- a/docs/source/examples/gist.rst
+++ b/docs/source/examples/gist.rst
@@ -55,7 +55,7 @@ Creating an anonymous gist
     print(gist.html_url)
 
 In the above examples ``'spam.txt'`` is the file name. GitHub will autodetect
-file type based on extension provided. ``'What... is the air-speed velocity of
+file type based on extension provided. ``'What… is the air-speed velocity of
 an unladen swallow?'`` is the file's content or body. ``'Answer this to cross
 the bridge'`` is the gist's description. While required by github3.py, it is
 allowed to be empty, e.g., ``''`` is accepted by GitHub.

--- a/docs/source/release-notes/1.0.0.rst
+++ b/docs/source/release-notes/1.0.0.rst
@@ -453,7 +453,7 @@ New Features
 
 - Add ``Organization#all_events``.
 
-- Add ``Tag.tagger_as_User`` which attempts to return the tagger as as User.
+- Add ``Tag.tagger_as_User`` which attempts to return the tagger as User.
 
 - Add ``Repo.statuses`` and a corresponding ``repo.status.CombinedStatus`` to
 
@@ -539,7 +539,7 @@ Bugs Fixed
   so we accidentally left out our actual hard dependencies.
 
 - The ``context`` parameter to ``Repository#create_status`` now properly
-  defaults to ``"default"``.
+  defaults to ``default``.
 
 - Fix AttributeError when ``IssueEvent`` has assignee.
 

--- a/docs/source/release-notes/2.1.0.rst
+++ b/docs/source/release-notes/2.1.0.rst
@@ -1,0 +1,7 @@
+2.1.0: 2021-09-09
+-----------------
+
+Features Added
+``````````````
+- Add ``maintainer_can_modify`` parameter to ``create_pull`` method of
+  ``Repo`` class.

--- a/docs/source/release-notes/index.rst
+++ b/docs/source/release-notes/index.rst
@@ -9,6 +9,7 @@ here with the newest releases first.
 ==================
 
 .. toctree::
+    2.1.0
     2.0.0
 
 1.x Release Series

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -1151,7 +1151,9 @@ class _Repository(models.GitHubCore):
         return self._instance_or_null(projects.Project, json)
 
     @decorators.requires_auth
-    def create_pull(self, title, base, head, body=None):
+    def create_pull(
+        self, title, base, head, body=None, maintainer_can_modify=None
+    ):
         """Create a pull request of ``head`` onto ``base`` branch in this repo.
 
         :param str title:
@@ -1162,12 +1164,17 @@ class _Repository(models.GitHubCore):
             (required), e.g., 'username:branch'
         :param str body:
             (optional), markdown formatted description
+        :param bool maintainer_can_modify:
+            (optional), Indicates whether a maintainer is allowed to modify the
+            pull request or not.
         :returns:
             the created pull request
         :rtype:
             :class:`~github3.pulls.ShortPullRequest`
         """
         data = {"title": title, "body": body, "base": base, "head": head}
+        if maintainer_can_modify is not None:
+            data["maintainer_can_modify"] = maintainer_can_modify
         return self._create_pull(data)
 
     @decorators.requires_auth

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -131,7 +131,7 @@ class TestGitHub(helper.UnitHelper):
         )
 
     def test_create_key_with_readonly(self):
-        """ Test the request to create a key with read only"""
+        """Test the request to create a key with read only"""
         self.instance.create_key("key_name", "key text", read_only=True)
 
         self.post_called_with(

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -348,7 +348,7 @@ class TestRepository(helper.UnitHelper):
             "base": "master",
             "head": "feature_branch",
             "body": "body",
-            "maintainer_can_modify": False
+            "maintainer_can_modify": False,
         }
         with unittest.mock.patch.object(Repository, "_create_pull") as pull:
             self.instance.create_pull(**data)

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -341,6 +341,19 @@ class TestRepository(helper.UnitHelper):
             self.instance.create_pull(**data)
             pull.assert_called_once_with(data)
 
+    def test_create_pull_maintainer_can_modify(self):
+        """Verify maintainer_can_modify option for creating a pull request."""
+        data = {
+            "title": "foo",
+            "base": "master",
+            "head": "feature_branch",
+            "body": "body",
+            "maintainer_can_modify": False
+        }
+        with unittest.mock.patch.object(Repository, "_create_pull") as pull:
+            self.instance.create_pull(**data)
+            pull.assert_called_once_with(data)
+
     def test_create_pull_from_issue(self):
         """Verify the request for creating a pull request from an issue."""
         with unittest.mock.patch.object(Repository, "_create_pull") as pull:


### PR DESCRIPTION
When we're creating a pull in the destination repo with credentials that don't have write permission on the source, we always get a 422 response from GitHub. This happens because maintainer_can_modify parameter is true by the default, and currently github3.py doesn't support setting of maintainer_can_modify to false when creating a PR.

This commit adds this parameter to create_pull Repo method to comply with GitHub API.

## Version Information
2.0.0

Please provide:

- The version of Python you're using
Python 3.9.6

- The version of pip you used to install github3.py
pip 21.2.4

- The version of github3.py, requests, uritemplate, and dateutil installed
requests                          2.26.0
uritemplate                       3.0.1

Fixes: #1031 
