### PR TITLE
Add rebaseable field to _PullRequest

### DIFF
--- a/src/github3/pulls.py
+++ b/src/github3/pulls.py
@@ -218,6 +218,7 @@ class _PullRequest(models.GitHubCore):
         self.merged_at = self._strptime(pull["merged_at"])
         self.number = pull["number"]
         self.patch_url = pull["patch_url"]
+        self.rebaseable = pull.get("rebaseable")
         requested_reviewers = pull.get("requested_reviewers", [])
         self.requested_reviewers = [
             users.ShortUser(r, self) for r in requested_reviewers
@@ -837,6 +838,11 @@ class ShortPullRequest(_PullRequest):
     .. attribute:: patch_url
 
         The URL to retrieve the patch for this pull request via the API.
+
+    .. attribute:: rebaseable
+
+        A boolean attribute indicating whether GitHub deems this pull request
+        is rebaseable. None if not set.
 
     .. attribute:: repository
 

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -196,6 +196,7 @@ class TestPullRequest(helper.UnitHelper):
         )
         assert not self.instance.merged
         assert self.instance.mergeable
+        assert not self.instance.rebaseable
 
 
 class TestPullReview(helper.UnitHelper):


### PR DESCRIPTION
According to the: https://docs.github.com/en/rest/reference/pulls#get-a-pull-request 
we could have `rebaseable` field in response.

<!-- links -->
[search]: https://github.com/sigmavirus24/github3.py/issues?utf8=%E2%9C%93&q=is%3Aissue
