### PR TITLE
Docs: Change index.rst example to use followers_of

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -204,3 +204,5 @@ Contributors
 - Dmitry Kiselev (@dmitrykiselev27)
 
 - Adeodato Simó (@dato)
+
+- Gunnar Andersson (@gunnarx)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,7 +35,7 @@ user:
     print(kennethreitz.login)
     print(kennethreitz.followers_count)
 
-    followers = [str(f) for f in gh.followers('kennethreitz')]
+    followers = [str(f) for f in gh.followers_of('kennethreitz')]
 
 There are several examples of different aspects of using github3.py
 


### PR DESCRIPTION
The last line in the initial example fails before this change.  The intention was probably to demonstrate the followers_of() function,
instead of followers()

(Sorry, I ignored your bug-report instructions in this PR.  The change should be self-explanatory I imagine).

A side note:  Filling the array for the 28000 followers of kennethreitz using the API seemed to take a substantial amount of time (?), so maybe another example would be a good idea.