### PR TITLE
Make "date" on tagger obj for create_tag optional

### DIFF
--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -1326,7 +1326,7 @@ class _Repository(models.GitHubCore):
             'blob'
         :param dict tagger:
             (required), containing the name, email of the
-            tagger and the date it was tagged
+            tagger and optionally the date it was tagged
         :param bool lightweight:
             (optional), if False, create an annotated
             tag, otherwise create a lightweight tag (a Reference).
@@ -1341,7 +1341,7 @@ class _Repository(models.GitHubCore):
             return self.create_ref("refs/tags/" + tag, sha)
 
         json = None
-        if tag and message and sha and obj_type and len(tagger) == 3:
+        if tag and message and sha and obj_type and len(tagger) == 2:
             data = {
                 "tag": tag,
                 "message": message,

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -1341,7 +1341,7 @@ class _Repository(models.GitHubCore):
             return self.create_ref("refs/tags/" + tag, sha)
 
         json = None
-        if tag and message and sha and obj_type and len(tagger) == 2:
+        if tag and message and sha and obj_type and len(tagger) >= 2:
             data = {
                 "tag": tag,
                 "message": message,


### PR DESCRIPTION
Currently the `create_tag` method mandates that on the `tagger` dict that `date` is set when in fact according to the GitHub API this is optional:
https://docs.github.com/en/rest/reference/git#tags
https://docs.github.com/en/enterprise-server@3.1/rest/reference/git#create-a-tag-object

## Version Information

Please provide:

- The version of Python you're using
`Python 3.8.7`

- The version of pip you used to install github3.py
`21.2.4`

- The version of github3.py, requests, uritemplate, and dateutil installed
`github3.py==2.0.0`
`requests==2.25.1`
`uritemplate==4.1.1`
`python-dateutil==2.8.1`

## Minimum Reproducible Example

`date` on `tagger` for `create_tag` is required currently when in fact it is actually optional in the API spec
