### PR TITLE
Return bytes from Contents.decoded for empty files

### DIFF
--- a/src/github3/repos/contents.py
+++ b/src/github3/repos/contents.py
@@ -85,7 +85,7 @@ class Contents(models.GitHubCore):
         self.content = content.get("content")
         self.encoding = content.get("encoding")
         self.decoded = self.content
-        if self.encoding == "base64" and self.content:
+        if self.encoding == "base64" and self.content is not None:
             self.decoded = b64decode(self.content.encode())
         self.download_url = content["download_url"]
         self.git_url = content["git_url"]

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -582,6 +582,30 @@ class TestRepository(helper.UnitHelper):
             url_for("contents/path/to/file.txt"), params={"ref": "some-sha"}
         )
 
+    def test_file_contents_works_for_empty_file(self):
+        """Verify file_contents works for an empty file edge case."""
+        mock_response = unittest.mock.MagicMock(status_code=200)
+        mock_response.json.return_value = {
+            "content": "",
+            "download_url": "",
+            "encoding": "base64",
+            "git_url": "",
+            "html_url": "",
+            "name": "",
+            "path": "",
+            "sha": "",
+            "size": "",
+            "type": "",
+            "url": "",
+            "_links": "",
+        }
+        self.session.get.return_value = mock_response
+
+        file_contents = self.instance.file_contents(
+            "path/to/empty_file.txt", ref="some-sha"
+        )
+        assert file_contents.decoded == b""
+
     def test_git_commit_required_sha(self):
         """Verify the request for retrieving a git commit from a repository."""
         self.instance.git_commit("")


### PR DESCRIPTION
According to the docs, Contents.decoded should return bytes. However, in the case of empty files, it currently returns str. Make it return bytes also for empty files.

Fixes: #1067

## Version Information

Python: 3.9.10
Pip: 20.0.2
github3.py: main (f642a27833d6bef93daf5bb27b35e5ddbcfbb773)
requests: 2.22.0
uritemplate: 4.1.1
dateutil: N.A

## Minimum Reproducible Example

```python
#! /usr/bin/python3.10

from os import getenv

from github3 import login

username = getenv("USERNAME")
password = getenv("PASSWORD")

g = login(username, password)
repo = g.repository(username, "github3.py")
file_contents = repo.file_contents("empty_file")
decoded = file_contents.decoded
print(f"{type(decoded)=}")
```

And the output when run against `main` branch:

```bash
type(decoded)=<class 'str'>
```

## Exception information

`Contents.decoded` is ordinarily of type `bytes` according to the docs & observed retrieving non-empty files. It's just `str` in the case of empty files.