### PR TITLE
Sign JWTs for github app auth using PyJWT instead of jwcrypto

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -208,3 +208,5 @@ Contributors
 - Gunnar Andersson (@gunnarx)
 
 - Thomas Lam (@lamcw)
+
+- David Glick (@davisagli)

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,14 @@ Dependencies
 
 - requests_
 - uritemplate_
+- python-dateutil_
+- PyJWT_
 
 .. _requests: https://github.com/kennethreitz/requests
 .. _uritemplate: https://github.com/sigmavirus24/uritemplate
+.. _python-dateutil: https://github.com/dateutil/dateutil
+.. _PyJWT: https://github.com/jpadilla/pyjwt
+
 
 Contributing
 ------------
@@ -45,13 +50,11 @@ this in a virtual environment. These need to be installed for the tests to run.
 Build status
 ~~~~~~~~~~~~
 
-You can find `master` build statuses for different environments.
+You can find build statuses for different environments.
 
 - Github_
-- appveyor_
 
 .. _Github: https://github.com/sigmavirus24/github3.py/actions
-.. _appveyor: https://ci.appveyor.com/project/sigmavirus24/github3-py/branch/master
 
 License
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,12 +27,12 @@ requires_dist =
     requests>=2.0
     uritemplate>=3.0.0
     python-dateutil>=2.6.0
-    jwcrypto>=0.5.0
+    PyJWT>=2.3.0
 
 [options]
 packages = find:
 install_requires =
-    jwcrypto>=0.5.0
+    PyJWT>=2.3.0
     python-dateutil>=2.6.0
     requests>=2.18
     uritemplate>=3.0.0

--- a/src/github3/apps.py
+++ b/src/github3/apps.py
@@ -4,8 +4,7 @@ https://developer.github.com/apps/building-github-apps/
 """
 import time
 
-from jwcrypto import jwk
-from jwcrypto import jwt
+import jwt
 
 from . import models
 from . import users
@@ -155,10 +154,6 @@ class Installation(models.GitHubCore):
         self.updated_at = self._strptime(json["updated_at"])
 
 
-def _load_private_key(pem_key_bytes):
-    return jwk.JWK.from_pem(pem_key_bytes)
-
-
 def create_token(private_key_pem, app_id, expire_in=TEN_MINUTES_AS_SECONDS):
     """Create an encrypted token for the specified App.
 
@@ -176,15 +171,13 @@ def create_token(private_key_pem, app_id, expire_in=TEN_MINUTES_AS_SECONDS):
     """
     if not isinstance(private_key_pem, bytes):
         raise ValueError('"private_key_pem" parameter must be byte-string')
-    key = _load_private_key(private_key_pem)
     now = int(time.time())
-    token = jwt.JWT(
-        header={"alg": "RS256"},
-        claims={"iat": now, "exp": now + expire_in, "iss": app_id},
-        algs=["RS256"],
+    token = jwt.encode(
+        payload={"iat": now, "exp": now + expire_in, "iss": app_id},
+        key=private_key_pem,
+        algorithm="RS256",
     )
-    token.make_signed_token(key)
-    return token.serialize()
+    return token
 
 
 def create_jwt_headers(


### PR DESCRIPTION
This replaces jwcrypto with PyJWT for signing JWTs for github app authentication, in order to avoid an LGPL-licensed dependency.

Also includes a few minor edits to the README.
