### PR TITLE
Add extra flag [crpyto] for PyJWT dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ requires_dist =
 [options]
 packages = find:
 install_requires =
-    PyJWT>=2.3.0
+    PyJWT[crypto]>=2.3.0
     python-dateutil>=2.6.0
     requests>=2.18
     uritemplate>=3.0.0


### PR DESCRIPTION
Add an extra flag for the PyJWT dependency so that the python cryptographic package is an explicit dependency which will be installed automatically together with github3.py. The problem is described in https://github.com/sigmavirus24/github3.py/issues/1077
