### PR TITLE
Flexible generation of JWT tokens

### DIFF
--- a/src/github3/apps.py
+++ b/src/github3/apps.py
@@ -3,6 +3,7 @@
 https://developer.github.com/apps/building-github-apps/
 """
 import time
+import typing as t
 
 import jwt
 
@@ -155,12 +156,16 @@ class Installation(models.GitHubCore):
 
 
 def create_token(
-    private_key_pem,
-    app_id,
-    expire_in=TEN_MINUTES_AS_SECONDS,
-    token_creator=None,
+    private_key_pem: t.Optional[bytes],
+    app_id: int,
+    expire_in: int = TEN_MINUTES_AS_SECONDS,
+    token_creator: t.Optional[t.Callable[[t.Dict], str]] = None,
 ):
     """Create an encrypted token for the specified App.
+
+    .. versionchanged:: 3.2.1
+
+        Added ``token_creator`` parameter.
 
     :param bytes private_key_pem:
         The bytes of the private key for this GitHub Application. None if
@@ -170,10 +175,11 @@ def create_token(
     :param int expire_in:
         The length in seconds for this token to be valid for.
         Default: 600 seconds (10 minutes)
-    :param token_creator:
-        A function that will create the JWT token. Pass this if using a vault
-        that does not hand out the private key but creates the signature
-        as part of the SDK.
+    :param func token_creator:
+        A function that accepts a payload as a dictionary and produces a
+        JWT token as a string. Pass this if using a vault that does not
+        hand out the private key but creates the signature as part of the
+        SDK.
     :returns:
         Serialized encrypted token.
     :rtype:

--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -1428,7 +1428,12 @@ class GitHub(models.GitHubCore):
         self.session.app_bearer_token_auth(token, expire_in)
 
     def login_as_app_installation(
-        self, private_key_pem, app_id, installation_id, expire_in=30
+        self,
+        private_key_pem,
+        app_id,
+        installation_id,
+        expire_in=30,
+        token_creator=None,
     ):
         """Login using your GitHub App's installation credentials.
 
@@ -1454,7 +1459,8 @@ class GitHub(models.GitHubCore):
             This method expires after 1 hour.
 
         :param bytes private_key_pem:
-            The bytes of the private key for this GitHub Application.
+            The bytes of the private key for this GitHub Application. None
+            if passing a token_creator
         :param int app_id:
             The integer identifier for this GitHub Application.
         :param int installation_id:
@@ -1466,6 +1472,10 @@ class GitHub(models.GitHubCore):
             the event that clock drift is significant between your machine and
             GitHub's servers, you can set this higher than 30.
             Default: 30
+        :param token_creator:
+            A function that will create the JWT token. Pass this if using a
+            vault that does not hand out the private key but creates the
+            signature as part of the SDK.
 
         .. _Authenticating as an Installation:
             https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation
@@ -1473,7 +1483,10 @@ class GitHub(models.GitHubCore):
             https://developer.github.com/v3/apps/#create-a-new-installation-token
         """
         jwt_token = apps.create_token(
-            private_key_pem, app_id, expire_in=expire_in
+            private_key_pem,
+            app_id,
+            expire_in=expire_in,
+            token_creator=token_creator,
         )
         bearer_auth = session.AppBearerTokenAuth(jwt_token, expire_in)
         url = self._build_url(

--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -1429,11 +1429,11 @@ class GitHub(models.GitHubCore):
 
     def login_as_app_installation(
         self,
-        private_key_pem,
-        app_id,
-        installation_id,
-        expire_in=30,
-        token_creator=None,
+        private_key_pem: t.Optional[bytes],
+        app_id: int,
+        installation_id: int,
+        expire_in: int = 30,
+        token_creator: t.Optional[t.Callable[[t.Dict], str]] = None,
     ):
         """Login using your GitHub App's installation credentials.
 
@@ -1442,6 +1442,10 @@ class GitHub(models.GitHubCore):
         .. versionchanged:: 3.0.0
 
             Added ``expire_in`` parameter.
+
+        .. versionchanged:: 3.2.1
+
+            Added ``token_creator`` parameter.
 
         .. seealso::
 
@@ -1472,10 +1476,11 @@ class GitHub(models.GitHubCore):
             the event that clock drift is significant between your machine and
             GitHub's servers, you can set this higher than 30.
             Default: 30
-        :param token_creator:
-            A function that will create the JWT token. Pass this if using a
-            vault that does not hand out the private key but creates the
-            signature as part of the SDK.
+        :param func token_creator:
+            A function that accepts a payload as a dictionary and produces a
+            JWT token as a string. Pass this if using a vault that does not
+            hand out the private key but creates the signature as part of the
+            SDK.
 
         .. _Authenticating as an Installation:
             https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation


### PR DESCRIPTION
This makes it possible to inject a function for signing
a JWT token with a private key.

The rationale is that libraries like azure keyvault will
take care of storing the private key, but will never actually
deliver the private key but rather does the signing of the
token as part of the SDK. This is more secure as the
app never actually sees the private key then.

Would like input on how to extend the tests for this function

Fixes #1087 
