### PR TITLE
add "permission" parameter to repo.add_collaborator

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -216,3 +216,5 @@ Contributors
 - Philipp Heil (@zkdev)
 
 - Petter Kvalvaag (@pettermk)
+
+- Peter Küffner (@kuepe-sl)

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -118,13 +118,16 @@ class _Repository(models.GitHubCore):
         return self._instance_or_null(pulls.ShortPullRequest, json)
 
     @decorators.requires_auth
-    def add_collaborator(self, username):
+    def add_collaborator(self, username, permission=None):
         """Add ``username`` as a collaborator to a repository.
 
         :param username:
             (required), username of the user
         :type username:
             str or :class:`~github3.users.User`
+        :param str permission:
+            (optional), permission to grant the collaborator, valid on organization repositories only
+            Can be 'pull', 'triage', 'push', 'maintain', 'admin' or an organization-defined custom role name.
         :returns:
             True if successful, False otherwise
         :rtype:
@@ -134,7 +137,12 @@ class _Repository(models.GitHubCore):
         url = self._build_url(
             "collaborators", str(username), base_url=self._api
         )
-        return self._boolean(self._put(url), 201, 404)
+        if permission:
+            data = {"permission": permission}
+            resp = self._put(url, data=jsonlib.dumps(data))
+        else:
+            resp = self._put(url)
+        return self._boolean(resp, 201, 404)
 
     def archive(self, format, path="", ref="master"):
         """Get the tarball or zipball archive for this repo at ref.

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -126,8 +126,10 @@ class _Repository(models.GitHubCore):
         :type username:
             str or :class:`~github3.users.User`
         :param str permission:
-            (optional), permission to grant the collaborator, valid on organization repositories only
-            Can be 'pull', 'triage', 'push', 'maintain', 'admin' or an organization-defined custom role name.
+            (optional), permission to grant the collaborator, valid on
+            organization repositories only.
+            Can be 'pull', 'triage', 'push', 'maintain', 'admin' or an
+            organization-defined custom role name.
         :returns:
             True if successful, False otherwise
         :rtype:

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -88,7 +88,7 @@ class TestRepository(helper.UnitHelper):
 
         self.session.put.assert_called_once_with(
             url_for("collaborators/sigmavirus24"),
-            data='{"permission": "admin"}'
+            data='{"permission": "admin"}',
         )
 
     def test_add_null_collaborator(self):

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -81,6 +81,16 @@ class TestRepository(helper.UnitHelper):
             url_for("collaborators/sigmavirus24")
         )
 
+    def test_add_collaborator_with_permission(self):
+        """Verify the request to add a collaborator to a repository with
+        `admin` permission."""
+        self.instance.add_collaborator("sigmavirus24", "admin")
+
+        self.session.put.assert_called_once_with(
+            url_for("collaborators/sigmavirus24"),
+            data='{"permission": "admin"}'
+        )
+
     def test_add_null_collaborator(self):
         """Verify no request is made when adding `None` as a collaborator."""
         self.instance.add_collaborator(None)


### PR DESCRIPTION
This PR adds the "permission" parameter to `repo.add_collaborator`, which was missing and is only valid for organisation repositories. (see [here](https://docs.github.com/en/rest/collaborators/collaborators#add-a-repository-collaborator--parameters))

Fixes #954