### PR TITLE
Allow to set GitHub API version

### DIFF
--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -2596,6 +2596,17 @@ class GitHub(models.GitHubCore):
         """
         self.session.params = {"client_id": id, "client_secret": secret}
 
+    def set_api_version(self, api_version):
+        """Allow to set a specific API version.
+
+        :param str api_version:
+            API version to send with X-GitHub-Api-Version header.
+            See https://docs.github.com/en/rest/overview/api-versions?apiVersion=2022-11-28 for details on API versions.
+        """  # noqa: E501
+        if not api_version:
+            return
+        self.session.headers.update({"X-GitHub-Api-Version": api_version})
+
     def set_user_agent(self, user_agent):
         """Allow the user to set their own user agent string.
 

--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -59,9 +59,21 @@ class GitHub(models.GitHubCore):
     call the GitHub object with authentication parameters.
     """
 
-    def __init__(self, username="", password="", token="", session=None):
-        """Create a new GitHub instance to talk to the API."""
+    def __init__(
+        self, username="", password="", token="", session=None, api_version=""
+    ):
+        """Create a new GitHub instance to talk to the API.
+
+        :param str api_version:
+            API version to send with X-GitHub-Api-Version header.
+            See https://docs.github.com/en/rest/overview/api-versions
+            for details about API versions.
+        """
         super().__init__({}, session or self.new_session())
+
+        if api_version:
+            self.session.headers.update({"X-GitHub-Api-Version": api_version})
+
         if token:
             self.login(username, token=token)
         elif username and password:
@@ -2595,17 +2607,6 @@ class GitHub(models.GitHubCore):
             40-character hexidecimal client_secret provided by GitHub
         """
         self.session.params = {"client_id": id, "client_secret": secret}
-
-    def set_api_version(self, api_version):
-        """Allow to set a specific API version.
-
-        :param str api_version:
-            API version to send with X-GitHub-Api-Version header.
-            See https://docs.github.com/en/rest/overview/api-versions?apiVersion=2022-11-28 for details on API versions.
-        """  # noqa: E501
-        if not api_version:
-            return
-        self.session.headers.update({"X-GitHub-Api-Version": api_version})
 
     def set_user_agent(self, user_agent):
         """Allow the user to set their own user agent string.

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -727,12 +727,6 @@ class TestGitHub(helper.UnitHelper):
 
         self.session.headers.update.called is False
 
-    def test_set_api_version(self):
-        self.instance.set_api_version("2022-11-28")
-        self.session.headers.update.assert_called_once_with(
-            {"X-GitHub-Api-Version": "2022-11-28"}
-        )
-
     def test_set_user_agent(self):
         self.instance.set_user_agent("github3py")
         self.session.headers.update.assert_called_once_with(
@@ -1395,6 +1389,14 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
             params={"per_page": 100, "q": "tom repos:>42 followers:>1000"},
             headers={},
         )
+
+    def test_api_version_header(_):
+        gh = GitHub(api_version="2022-11-28")
+        assert gh.session.headers.get("X-GitHub-Api-Version") == "2022-11-28"
+
+    def test_api_version_header_not_defined(_):
+        gh = GitHub()
+        assert gh.session.headers.get("X-GitHub-Api-Version") is None
 
 
 class TestGitHubRequiresAuthentication(

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -727,6 +727,12 @@ class TestGitHub(helper.UnitHelper):
 
         self.session.headers.update.called is False
 
+    def test_set_api_version(self):
+        self.instance.set_api_version("2022-11-28")
+        self.session.headers.update.assert_called_once_with(
+            {"X-GitHub-Api-Version": "2022-11-28"}
+        )
+
     def test_set_user_agent(self):
         self.instance.set_user_agent("github3py")
         self.session.headers.update.assert_called_once_with(


### PR DESCRIPTION
This adds a new `set_api_version` method the `GitHub` class that accepts an API version string as defined [here](https://docs.github.com/en/rest/overview/api-versions?apiVersion=2022-11-28).  The version is added to the session headers.  Sessions headers remain unchanged if no version string was given.

Addresses #1121.
