### PR TITLE
Create release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: "Build dists"
+    runs-on: "ubuntu-latest"
+    environment:
+      name: "publish"
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3"
+
+      - name: "Setup Python"
+        uses: "actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b"
+        with:
+          python-version: "3.x"
+
+      - name: "Install dependencies"
+        run: python -m pip install build==0.8.0
+
+      - name: "Build dists"
+        run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
+          python -m build
+
+      - name: "Generate hashes"
+        id: hash
+        run: |
+          cd dist && echo "::set-output name=hashes::$(sha256sum * | base64 -w0)"
+
+      - name: "Upload dists"
+        uses: "actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce"
+        with:
+          name: "dist"
+          path: "dist/"
+          if-no-files-found: error
+          retention-days: 5
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read
+      contents: write
+      id-token: write # Needed to access the workflow's OIDC identity.
+    uses: "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.5.0"
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true
+      compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
+
+  publish:
+    name: "Publish"
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: ["build", "provenance"]
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: "ubuntu-latest"
+
+    steps:
+    - name: "Download dists"
+      uses: "actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a"
+      with:
+        name: "dist"
+        path: "dist/"
+
+    - name: "Publish dists to PyPI"
+      uses: "pypa/gh-action-pypi-publish@48b317d84d5f59668bb13be49d1697e36b3ad009"


### PR DESCRIPTION
This uses trusted publishers with PyPI to avoid having to store a token so that 