### PR TITLE
Support per_page search parameter

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -222,3 +222,5 @@ Contributors
 - Andrew MacCormack (@amaccormack-lumira)
 
 - Chris R (@offbyone)
+
+- Chris Cotter (@ccotter)

--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -2248,6 +2248,9 @@ class GitHub(models.GitHubCore):
         if sort and order in ("asc", "desc"):
             params["order"] = order
 
+        if per_page is not None:
+            params["per_page"] = per_page
+
         if text_match:
             headers = {
                 "Accept": "application/vnd.github.v3.full.text-match+json"
@@ -2334,6 +2337,9 @@ class GitHub(models.GitHubCore):
 
         if sort and order in ("asc", "desc"):
             params["order"] = order
+
+        if per_page is not None:
+            params["per_page"] = per_page
 
         if text_match:
             headers["Accept"] = ", ".join(
@@ -2427,6 +2433,9 @@ class GitHub(models.GitHubCore):
         if order in ("asc", "desc"):
             params["order"] = order
 
+        if per_page is not None:
+            params["per_page"] = per_page
+
         if text_match:
             headers = {
                 "Accept": "application/vnd.github.v3.full.text-match+json"
@@ -2504,6 +2513,9 @@ class GitHub(models.GitHubCore):
 
         if order in ("asc", "desc"):
             params["order"] = order
+
+        if per_page is not None:
+            params["per_page"] = per_page
 
         if text_match:
             headers = {
@@ -2587,6 +2599,9 @@ class GitHub(models.GitHubCore):
 
         if order in ("asc", "desc"):
             params["order"] = order
+
+        if per_page is not None:
+            params["per_page"] = per_page
 
         if text_match:
             headers = {

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -1332,7 +1332,9 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
 
     def test_search_commits(self):
         """Verify the request to search for commits."""
-        i = self.instance.search_commits("css repo:octocat/Spoon-Knife", per_page=15)
+        i = self.instance.search_commits(
+            "css repo:octocat/Spoon-Knife", per_page=15
+        )
         self.get_next(i)
 
         self.session.get.assert_called_once_with(
@@ -1393,7 +1395,9 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
 
     def test_search_users(self):
         """Verify the request to search for users."""
-        i = self.instance.search_users("tom repos:>42 followers:>1000", per_page=15)
+        i = self.instance.search_users(
+            "tom repos:>42 followers:>1000", per_page=15
+        )
         self.get_next(i)
 
         self.session.get.assert_called_once_with(

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -1317,14 +1317,14 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
     def test_search_code(self):
         """Verify the request to search for code."""
         i = self.instance.search_code(
-            "addClass in:file language:js repo:jquery/jquery"
+            "addClass in:file language:js repo:jquery/jquery", per_page=15
         )
         self.get_next(i)
 
         self.session.get.assert_called_once_with(
             url_for("search/code"),
             params={
-                "per_page": 100,
+                "per_page": 15,
                 "q": "addClass in:file language:js repo:jquery/jquery",
             },
             headers={},
@@ -1332,6 +1332,17 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
 
     def test_search_commits(self):
         """Verify the request to search for commits."""
+        i = self.instance.search_commits("css repo:octocat/Spoon-Knife", per_page=15)
+        self.get_next(i)
+
+        self.session.get.assert_called_once_with(
+            url_for("search/commits"),
+            params={"per_page": 15, "q": "css repo:octocat/Spoon-Knife"},
+            headers={"Accept": "application/vnd.github.cloak-preview"},
+        )
+
+    def test_search_commits_default_per_page(self):
+        """Verify the default per_page in the commits search."""
         i = self.instance.search_commits("css repo:octocat/Spoon-Knife")
         self.get_next(i)
 
@@ -1347,6 +1358,7 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
             "windows label:bug language:python state:open",
             sort="created",
             order="asc",
+            per_page=15,
         )
         self.get_next(i)
 
@@ -1354,7 +1366,7 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
             url_for("search/issues"),
             params={
                 "order": "asc",
-                "per_page": 100,
+                "per_page": 15,
                 "q": "windows label:bug language:python state:open",
                 "sort": "created",
             },
@@ -1364,7 +1376,7 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
     def test_search_repositories(self):
         """Verify the request to search for repositories."""
         i = self.instance.search_repositories(
-            "tetris language:assembly", sort="stars", order="asc"
+            "tetris language:assembly", sort="stars", order="asc", per_page=15
         )
         self.get_next(i)
 
@@ -1372,7 +1384,7 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
             url_for("search/repositories"),
             params={
                 "order": "asc",
-                "per_page": 100,
+                "per_page": 15,
                 "q": "tetris language:assembly",
                 "sort": "stars",
             },
@@ -1381,12 +1393,12 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
 
     def test_search_users(self):
         """Verify the request to search for users."""
-        i = self.instance.search_users("tom repos:>42 followers:>1000")
+        i = self.instance.search_users("tom repos:>42 followers:>1000", per_page=15)
         self.get_next(i)
 
         self.session.get.assert_called_once_with(
             url_for("search/users"),
-            params={"per_page": 100, "q": "tom repos:>42 followers:>1000"},
+            params={"per_page": 15, "q": "tom repos:>42 followers:>1000"},
             headers={},
         )
 


### PR DESCRIPTION
Update the following search_* APIs to forward the `per_page` parameter.
 - search_code
 - search_commits
 - search_issues
 - search_repositories
 - search_users

Test plan: updated unit tests to verify per_page parameter. Tested manually by query `search_issues(..., per_page=1)` and verified the results arrived one at a time in each http response.

Closes #1166

## Version Information

Python 3.10, using the latest version of github3.py (main branch)

## Minimum Reproducible Example

```
gh.search_issues(..., per_page=1) # The actual parameter sent in the http request is per_page=100
```