### PR TITLE
chore: switch to isort from reorder python imports

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Please provide:
 
 - The version of pip you used to install github3.py
 
-- The version of github3.py, requests, uritemplate, and dateutil installed
+- The version of github3.py, requests, uritemplate, and python-dateutil installed
 
 ## Minimum Reproducible Example
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,11 @@ repos:
     - id: trailing-whitespace
       types: [text]
       stages: [commit, push, manual]
-  - repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
     hooks:
-    - id: reorder-python-imports
-      args: [--application-directories, '.:src', --py37-plus]
+    - id: isort
+      args: [--profile, black]
   - repo: https://github.com/psf/black
     rev: 23.12.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
     rev: 5.13.2
     hooks:
     - id: isort
-      args: [--profile, black]
   - repo: https://github.com/psf/black
     rev: 23.12.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,4 @@ exclude = [
 
 [tool.isort]
 profile = "black"
+line_length = 78

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,3 +97,4 @@ exclude = [
 [tool.isort]
 profile = "black"
 line_length = 78
+force_single_line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,6 @@ exclude = [
     "^docs/",
     "^tests/",
 ]
+
+[tool.isort]
+profile = "black"

--- a/src/github3/__about__.py
+++ b/src/github3/__about__.py
@@ -1,4 +1,5 @@
 """The module that holds much of the metadata about github3.py."""
+
 __package_name__ = "github3.py"
 __title__ = "github3"
 __author__ = "Ian Stapleton Cordasco"

--- a/src/github3/__init__.py
+++ b/src/github3/__init__.py
@@ -9,20 +9,20 @@ See https://github3.readthedocs.io/ for documentation.
 
 """
 
-from .__about__ import (
-    __author__,
-    __author_email__,
-    __copyright__,
-    __license__,
-    __package_name__,
-    __title__,
-    __url__,
-    __version__,
-    __version_info__,
-)
-from .api import enterprise_login, login
+from .__about__ import __author__
+from .__about__ import __author_email__
+from .__about__ import __copyright__
+from .__about__ import __license__
+from .__about__ import __package_name__
+from .__about__ import __title__
+from .__about__ import __url__
+from .__about__ import __version__
+from .__about__ import __version_info__
+from .api import enterprise_login
+from .api import login
 from .exceptions import GitHubError
-from .github import GitHub, GitHubEnterprise
+from .github import GitHub
+from .github import GitHubEnterprise
 
 __all__ = (
     "GitHub",

--- a/src/github3/__init__.py
+++ b/src/github3/__init__.py
@@ -8,6 +8,7 @@ See https://github3.readthedocs.io/ for documentation.
 :license: Modified BSD, see LICENSE for more details
 
 """
+
 from .__about__ import (
     __author__,
     __author_email__,

--- a/src/github3/__init__.py
+++ b/src/github3/__init__.py
@@ -8,20 +8,20 @@ See https://github3.readthedocs.io/ for documentation.
 :license: Modified BSD, see LICENSE for more details
 
 """
-from .__about__ import __author__
-from .__about__ import __author_email__
-from .__about__ import __copyright__
-from .__about__ import __license__
-from .__about__ import __package_name__
-from .__about__ import __title__
-from .__about__ import __url__
-from .__about__ import __version__
-from .__about__ import __version_info__
-from .api import enterprise_login
-from .api import login
+from .__about__ import (
+    __author__,
+    __author_email__,
+    __copyright__,
+    __license__,
+    __package_name__,
+    __title__,
+    __url__,
+    __version__,
+    __version_info__,
+)
+from .api import enterprise_login, login
 from .exceptions import GitHubError
-from .github import GitHub
-from .github import GitHubEnterprise
+from .github import GitHub, GitHubEnterprise
 
 __all__ = (
     "GitHub",

--- a/src/github3/api.py
+++ b/src/github3/api.py
@@ -6,8 +6,7 @@ github3.api
 :license: Modified BSD, see LICENSE for more details
 
 """
-from .github import GitHub
-from .github import GitHubEnterprise
+from .github import GitHub, GitHubEnterprise
 
 gh = GitHub()
 

--- a/src/github3/api.py
+++ b/src/github3/api.py
@@ -6,6 +6,7 @@ github3.api
 :license: Modified BSD, see LICENSE for more details
 
 """
+
 from .github import GitHub, GitHubEnterprise
 
 gh = GitHub()

--- a/src/github3/api.py
+++ b/src/github3/api.py
@@ -7,7 +7,8 @@ github3.api
 
 """
 
-from .github import GitHub, GitHubEnterprise
+from .github import GitHub
+from .github import GitHubEnterprise
 
 gh = GitHub()
 

--- a/src/github3/apps.py
+++ b/src/github3/apps.py
@@ -6,8 +6,7 @@ import time
 
 import jwt
 
-from . import models
-from . import users
+from . import models, users
 
 TEN_MINUTES_AS_SECONDS = 10 * 60
 DEFAULT_JWT_TOKEN_EXPIRATION = TEN_MINUTES_AS_SECONDS

--- a/src/github3/apps.py
+++ b/src/github3/apps.py
@@ -7,7 +7,8 @@ import time
 
 import jwt
 
-from . import models, users
+from . import models
+from . import users
 
 TEN_MINUTES_AS_SECONDS = 10 * 60
 DEFAULT_JWT_TOKEN_EXPIRATION = TEN_MINUTES_AS_SECONDS

--- a/src/github3/apps.py
+++ b/src/github3/apps.py
@@ -2,6 +2,7 @@
 
 https://developer.github.com/apps/building-github-apps/
 """
+
 import time
 
 import jwt

--- a/src/github3/auths.py
+++ b/src/github3/auths.py
@@ -1,4 +1,5 @@
 """This module contains the Authorization object."""
+
 from .decorators import requires_basic_auth
 from .models import GitHubCore
 

--- a/src/github3/checks.py
+++ b/src/github3/checks.py
@@ -1,8 +1,7 @@
 """This module contains all the classes relating to Checks."""
 from json import dumps
 
-from . import decorators
-from . import models
+from . import decorators, models
 
 
 class CheckPullRequest(models.GitHubCore):

--- a/src/github3/checks.py
+++ b/src/github3/checks.py
@@ -2,7 +2,8 @@
 
 from json import dumps
 
-from . import decorators, models
+from . import decorators
+from . import models
 
 
 class CheckPullRequest(models.GitHubCore):

--- a/src/github3/checks.py
+++ b/src/github3/checks.py
@@ -1,4 +1,5 @@
 """This module contains all the classes relating to Checks."""
+
 from json import dumps
 
 from . import decorators, models

--- a/src/github3/decorators.py
+++ b/src/github3/decorators.py
@@ -1,4 +1,5 @@
 """This module provides decorators to the rest of the library."""
+
 import os
 from functools import wraps
 from io import BytesIO as StringIO

--- a/src/github3/events.py
+++ b/src/github3/events.py
@@ -1,4 +1,5 @@
 """This module contains the classes related to Events."""
+
 import copy
 
 from . import models

--- a/src/github3/gists/__init__.py
+++ b/src/github3/gists/__init__.py
@@ -13,6 +13,7 @@ Sub-modules:
 See also: http://developer.github.com/v3/gists/
 """
 
-from .gist import Gist, ShortGist
+from .gist import Gist
+from .gist import ShortGist
 
 __all__ = ("Gist", "ShortGist")

--- a/src/github3/gists/__init__.py
+++ b/src/github3/gists/__init__.py
@@ -12,6 +12,7 @@ Sub-modules:
 
 See also: http://developer.github.com/v3/gists/
 """
+
 from .gist import Gist, ShortGist
 
 __all__ = ("Gist", "ShortGist")

--- a/src/github3/gists/__init__.py
+++ b/src/github3/gists/__init__.py
@@ -12,7 +12,6 @@ Sub-modules:
 
 See also: http://developer.github.com/v3/gists/
 """
-from .gist import Gist
-from .gist import ShortGist
+from .gist import Gist, ShortGist
 
 __all__ = ("Gist", "ShortGist")

--- a/src/github3/gists/comment.py
+++ b/src/github3/gists/comment.py
@@ -1,4 +1,5 @@
 """Module containing the logic for a GistComment."""
+
 from .. import decorators, models, users
 
 

--- a/src/github3/gists/comment.py
+++ b/src/github3/gists/comment.py
@@ -1,7 +1,5 @@
 """Module containing the logic for a GistComment."""
-from .. import decorators
-from .. import models
-from .. import users
+from .. import decorators, models, users
 
 
 class GistComment(models.GitHubCore):

--- a/src/github3/gists/comment.py
+++ b/src/github3/gists/comment.py
@@ -1,6 +1,8 @@
 """Module containing the logic for a GistComment."""
 
-from .. import decorators, models, users
+from .. import decorators
+from .. import models
+from .. import users
 
 
 class GistComment(models.GitHubCore):

--- a/src/github3/gists/file.py
+++ b/src/github3/gists/file.py
@@ -1,4 +1,5 @@
 """Module containing the GistFile object."""
+
 from .. import models
 
 

--- a/src/github3/gists/gist.py
+++ b/src/github3/gists/gist.py
@@ -2,12 +2,11 @@
 import typing as t
 from json import dumps
 
+from .. import models, users
+from ..decorators import requires_auth
 from . import comment
 from . import file as gistfile
 from . import history
-from .. import models
-from .. import users
-from ..decorators import requires_auth
 
 
 class _Gist(models.GitHubCore):

--- a/src/github3/gists/gist.py
+++ b/src/github3/gists/gist.py
@@ -3,7 +3,8 @@
 import typing as t
 from json import dumps
 
-from .. import models, users
+from .. import models
+from .. import users
 from ..decorators import requires_auth
 from . import comment
 from . import file as gistfile

--- a/src/github3/gists/gist.py
+++ b/src/github3/gists/gist.py
@@ -1,4 +1,5 @@
 """This module contains the Gist, ShortGist, and GistFork objects."""
+
 import typing as t
 from json import dumps
 

--- a/src/github3/gists/history.py
+++ b/src/github3/gists/history.py
@@ -1,6 +1,5 @@
 """Module containing the GistHistory object."""
-from .. import models
-from .. import users
+from .. import models, users
 
 
 class GistHistory(models.GitHubCore):

--- a/src/github3/gists/history.py
+++ b/src/github3/gists/history.py
@@ -1,4 +1,5 @@
 """Module containing the GistHistory object."""
+
 from .. import models, users
 
 

--- a/src/github3/gists/history.py
+++ b/src/github3/gists/history.py
@@ -1,6 +1,7 @@
 """Module containing the GistHistory object."""
 
-from .. import models, users
+from .. import models
+from .. import users
 
 
 class GistHistory(models.GitHubCore):

--- a/src/github3/git.py
+++ b/src/github3/git.py
@@ -3,6 +3,7 @@ This module contains all the classes relating to Git Data.
 
 See also: http://developer.github.com/v3/git/
 """
+
 import base64
 from json import dumps
 

--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -24,7 +24,11 @@ from . import (
     users,
     utils,
 )
-from .decorators import requires_app_credentials, requires_auth, requires_basic_auth
+from .decorators import (
+    requires_app_credentials,
+    requires_auth,
+    requires_basic_auth,
+)
 from .repos import invitation, repo
 
 _pubsub_re = re.compile(

--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -5,29 +5,27 @@ import typing as t
 
 import uritemplate  # type: ignore
 
-from . import apps
-from . import auths
-from . import decorators
-from . import events
-from . import gists
-from . import issues
-from . import licenses
-from . import models
-from . import notifications
-from . import orgs
-from . import projects
-from . import pulls
-from . import search
-from . import session
-from . import structs
-from . import users
-from . import utils
-from .decorators import requires_app_credentials
-from .decorators import requires_auth
-from .decorators import requires_basic_auth
-from .repos import invitation
-from .repos import repo
-
+from . import (
+    apps,
+    auths,
+    decorators,
+    events,
+    gists,
+    issues,
+    licenses,
+    models,
+    notifications,
+    orgs,
+    projects,
+    pulls,
+    search,
+    session,
+    structs,
+    users,
+    utils,
+)
+from .decorators import requires_app_credentials, requires_auth, requires_basic_auth
+from .repos import invitation, repo
 
 _pubsub_re = re.compile(
     r"https?://[\w\d\-\.\:]+/\w[\w-]+\w/[\w\._-]+/events/\w+"

--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -6,31 +6,28 @@ import typing as t
 
 import uritemplate  # type: ignore
 
-from . import (
-    apps,
-    auths,
-    decorators,
-    events,
-    gists,
-    issues,
-    licenses,
-    models,
-    notifications,
-    orgs,
-    projects,
-    pulls,
-    search,
-    session,
-    structs,
-    users,
-    utils,
-)
-from .decorators import (
-    requires_app_credentials,
-    requires_auth,
-    requires_basic_auth,
-)
-from .repos import invitation, repo
+from . import apps
+from . import auths
+from . import decorators
+from . import events
+from . import gists
+from . import issues
+from . import licenses
+from . import models
+from . import notifications
+from . import orgs
+from . import projects
+from . import pulls
+from . import search
+from . import session
+from . import structs
+from . import users
+from . import utils
+from .decorators import requires_app_credentials
+from .decorators import requires_auth
+from .decorators import requires_basic_auth
+from .repos import invitation
+from .repos import repo
 
 _pubsub_re = re.compile(
     r"https?://[\w\d\-\.\:]+/\w[\w-]+\w/[\w\._-]+/events/\w+"

--- a/src/github3/github.py
+++ b/src/github3/github.py
@@ -1,4 +1,5 @@
 """This module contains the main interfaces to the API."""
+
 import json
 import re
 import typing as t

--- a/src/github3/issues/__init__.py
+++ b/src/github3/issues/__init__.py
@@ -6,6 +6,7 @@ This module contains the classes related to issues.
 
 See also: http://developer.github.com/v3/issues/
 """
+
 from ..utils import timestamp_parameter
 from .issue import Issue, ShortIssue
 

--- a/src/github3/issues/__init__.py
+++ b/src/github3/issues/__init__.py
@@ -8,7 +8,8 @@ See also: http://developer.github.com/v3/issues/
 """
 
 from ..utils import timestamp_parameter
-from .issue import Issue, ShortIssue
+from .issue import Issue
+from .issue import ShortIssue
 
 __all__ = ["Issue", "ShortIssue"]
 

--- a/src/github3/issues/__init__.py
+++ b/src/github3/issues/__init__.py
@@ -7,8 +7,7 @@ This module contains the classes related to issues.
 See also: http://developer.github.com/v3/issues/
 """
 from ..utils import timestamp_parameter
-from .issue import Issue
-from .issue import ShortIssue
+from .issue import Issue, ShortIssue
 
 __all__ = ["Issue", "ShortIssue"]
 

--- a/src/github3/issues/comment.py
+++ b/src/github3/issues/comment.py
@@ -1,8 +1,5 @@
 """Module with class(es) representing issue comments."""
-from .. import decorators
-from .. import models
-from .. import users
-from .. import utils
+from .. import decorators, models, users, utils
 
 
 class IssueComment(models.GitHubCore):

--- a/src/github3/issues/comment.py
+++ b/src/github3/issues/comment.py
@@ -1,6 +1,9 @@
 """Module with class(es) representing issue comments."""
 
-from .. import decorators, models, users, utils
+from .. import decorators
+from .. import models
+from .. import users
+from .. import utils
 
 
 class IssueComment(models.GitHubCore):

--- a/src/github3/issues/comment.py
+++ b/src/github3/issues/comment.py
@@ -1,4 +1,5 @@
 """Module with class(es) representing issue comments."""
+
 from .. import decorators, models, users, utils
 
 

--- a/src/github3/issues/event.py
+++ b/src/github3/issues/event.py
@@ -1,4 +1,5 @@
 """Issue events logic."""
+
 from .. import users
 from ..models import GitHubCore
 

--- a/src/github3/issues/issue.py
+++ b/src/github3/issues/issue.py
@@ -1,4 +1,5 @@
 """Module containing the Issue logic."""
+
 from json import dumps
 
 from uritemplate import URITemplate  # type: ignore

--- a/src/github3/issues/issue.py
+++ b/src/github3/issues/issue.py
@@ -4,9 +4,13 @@ from json import dumps
 
 from uritemplate import URITemplate  # type: ignore
 
-from .. import models, users
+from .. import models
+from .. import users
 from ..decorators import requires_auth
-from . import comment, event, label, milestone
+from . import comment
+from . import event
+from . import label
+from . import milestone
 
 
 class _Issue(models.GitHubCore):

--- a/src/github3/issues/issue.py
+++ b/src/github3/issues/issue.py
@@ -3,13 +3,9 @@ from json import dumps
 
 from uritemplate import URITemplate  # type: ignore
 
-from . import comment
-from . import event
-from . import label
-from . import milestone
-from .. import models
-from .. import users
+from .. import models, users
 from ..decorators import requires_auth
+from . import comment, event, label, milestone
 
 
 class _Issue(models.GitHubCore):

--- a/src/github3/issues/label.py
+++ b/src/github3/issues/label.py
@@ -1,4 +1,5 @@
 """Module containing the logic for labels."""
+
 from json import dumps
 
 from ..decorators import requires_auth

--- a/src/github3/issues/milestone.py
+++ b/src/github3/issues/milestone.py
@@ -1,9 +1,9 @@
 from json import dumps
 
-from . import label
 from .. import users
 from ..decorators import requires_auth
 from ..models import GitHubCore
+from . import label
 
 
 class Milestone(GitHubCore):

--- a/src/github3/licenses.py
+++ b/src/github3/licenses.py
@@ -3,6 +3,7 @@ This module contains the classes relating to licenses.
 
 See also: https://developer.github.com/v3/licenses/
 """
+
 import base64
 
 from . import models

--- a/src/github3/models.py
+++ b/src/github3/models.py
@@ -1,4 +1,5 @@
 """This module provides the basic models used in github3.py."""
+
 import json as jsonlib
 import logging
 import typing as t

--- a/src/github3/models.py
+++ b/src/github3/models.py
@@ -6,9 +6,7 @@ import typing as t
 import dateutil.parser
 import requests.compat
 
-from . import exceptions
-from . import session
-
+from . import exceptions, session
 
 if t.TYPE_CHECKING:
     from . import structs

--- a/src/github3/models.py
+++ b/src/github3/models.py
@@ -7,7 +7,8 @@ import typing as t
 import dateutil.parser
 import requests.compat
 
-from . import exceptions, session
+from . import exceptions
+from . import session
 
 if t.TYPE_CHECKING:
     from . import structs

--- a/src/github3/notifications.py
+++ b/src/github3/notifications.py
@@ -3,6 +3,7 @@ This module contains the classes relating to notifications.
 
 See also: http://developer.github.com/v3/activity/notifications/
 """
+
 from json import dumps
 
 from . import models

--- a/src/github3/orgs.py
+++ b/src/github3/orgs.py
@@ -5,11 +5,13 @@ from json import dumps
 
 from uritemplate import URITemplate  # type: ignore
 
-from . import models, users
+from . import models
+from . import users
 from .decorators import requires_auth
 from .events import Event
 from .projects import Project
-from .repos import Repository, ShortRepository
+from .repos import Repository
+from .repos import ShortRepository
 
 if t.TYPE_CHECKING:
     from . import users as _users

--- a/src/github3/orgs.py
+++ b/src/github3/orgs.py
@@ -1,4 +1,5 @@
 """This module contains all of the classes related to organizations."""
+
 import typing as t
 from json import dumps
 

--- a/src/github3/orgs.py
+++ b/src/github3/orgs.py
@@ -4,13 +4,11 @@ from json import dumps
 
 from uritemplate import URITemplate  # type: ignore
 
-from . import models
-from . import users
+from . import models, users
 from .decorators import requires_auth
 from .events import Event
 from .projects import Project
-from .repos import Repository
-from .repos import ShortRepository
+from .repos import Repository, ShortRepository
 
 if t.TYPE_CHECKING:
     from . import users as _users

--- a/src/github3/projects.py
+++ b/src/github3/projects.py
@@ -2,7 +2,10 @@
 
 from json import dumps
 
-from . import exceptions, models, pulls, users
+from . import exceptions
+from . import models
+from . import pulls
+from . import users
 from .decorators import requires_auth
 from .issues import issue
 

--- a/src/github3/projects.py
+++ b/src/github3/projects.py
@@ -1,10 +1,7 @@
 """This module contains all the classes relating to projects."""
 from json import dumps
 
-from . import exceptions
-from . import models
-from . import pulls
-from . import users
+from . import exceptions, models, pulls, users
 from .decorators import requires_auth
 from .issues import issue
 

--- a/src/github3/projects.py
+++ b/src/github3/projects.py
@@ -1,4 +1,5 @@
 """This module contains all the classes relating to projects."""
+
 from json import dumps
 
 from . import exceptions, models, pulls, users

--- a/src/github3/pulls.py
+++ b/src/github3/pulls.py
@@ -4,7 +4,8 @@ from json import dumps
 
 from uritemplate import URITemplate  # type: ignore
 
-from . import models, users
+from . import models
+from . import users
 from .decorators import requires_auth
 from .issues import Issue
 from .issues.comment import IssueComment

--- a/src/github3/pulls.py
+++ b/src/github3/pulls.py
@@ -3,8 +3,7 @@ from json import dumps
 
 from uritemplate import URITemplate  # type: ignore
 
-from . import models
-from . import users
+from . import models, users
 from .decorators import requires_auth
 from .issues import Issue
 from .issues.comment import IssueComment

--- a/src/github3/pulls.py
+++ b/src/github3/pulls.py
@@ -1,4 +1,5 @@
 """This module contains all the classes relating to pull requests."""
+
 from json import dumps
 
 from uritemplate import URITemplate  # type: ignore

--- a/src/github3/repos/__init__.py
+++ b/src/github3/repos/__init__.py
@@ -7,6 +7,8 @@ This module contains the classes relating to repositories.
 See also: http://developer.github.com/v3/repos/
 """
 
-from .repo import Repository, ShortRepository, StarredRepository
+from .repo import Repository
+from .repo import ShortRepository
+from .repo import StarredRepository
 
 __all__ = ("Repository", "ShortRepository", "StarredRepository")

--- a/src/github3/repos/__init__.py
+++ b/src/github3/repos/__init__.py
@@ -6,8 +6,6 @@ This module contains the classes relating to repositories.
 
 See also: http://developer.github.com/v3/repos/
 """
-from .repo import Repository
-from .repo import ShortRepository
-from .repo import StarredRepository
+from .repo import Repository, ShortRepository, StarredRepository
 
 __all__ = ("Repository", "ShortRepository", "StarredRepository")

--- a/src/github3/repos/__init__.py
+++ b/src/github3/repos/__init__.py
@@ -6,6 +6,7 @@ This module contains the classes relating to repositories.
 
 See also: http://developer.github.com/v3/repos/
 """
+
 from .repo import Repository, ShortRepository, StarredRepository
 
 __all__ = ("Repository", "ShortRepository", "StarredRepository")

--- a/src/github3/repos/branch.py
+++ b/src/github3/repos/branch.py
@@ -1,4 +1,5 @@
 """Implementation of a branch on a repository."""
+
 import typing as t
 
 from .. import decorators, models
@@ -152,9 +153,9 @@ class _Branch(models.GitHubCore):
         if allow_deletions is not None:
             edit["allow_deletions"] = allow_deletions
         if required_conversation_resolution is not None:
-            edit[
-                "required_conversation_resolution"
-            ] = required_conversation_resolution
+            edit["required_conversation_resolution"] = (
+                required_conversation_resolution
+            )
         url = self._build_url("protection", base_url=self._api)
         resp = self._put(url, json=edit)
         json = self._json(resp, 200)

--- a/src/github3/repos/branch.py
+++ b/src/github3/repos/branch.py
@@ -2,7 +2,8 @@
 
 import typing as t
 
-from .. import decorators, models
+from .. import decorators
+from .. import models
 from . import commit
 
 if t.TYPE_CHECKING:
@@ -603,7 +604,9 @@ class ProtectionRestrictions(models.GitHubCore):
     """
 
     def _update_attributes(self, protection):
-        from .. import apps, orgs, users
+        from .. import apps
+        from .. import orgs
+        from .. import users
 
         self._api = protection["url"]
         self.users_url = protection["users_url"]

--- a/src/github3/repos/branch.py
+++ b/src/github3/repos/branch.py
@@ -1,14 +1,13 @@
 """Implementation of a branch on a repository."""
 import typing as t
 
+from .. import decorators, models
 from . import commit
-from .. import decorators
-from .. import models
 
 if t.TYPE_CHECKING:
     from .. import apps as tapps
-    from .. import users as tusers
     from .. import orgs
+    from .. import users as tusers
 
 
 class _Branch(models.GitHubCore):

--- a/src/github3/repos/branch.py
+++ b/src/github3/repos/branch.py
@@ -153,9 +153,9 @@ class _Branch(models.GitHubCore):
         if allow_deletions is not None:
             edit["allow_deletions"] = allow_deletions
         if required_conversation_resolution is not None:
-            edit["required_conversation_resolution"] = (
-                required_conversation_resolution
-            )
+            edit[
+                "required_conversation_resolution"
+            ] = required_conversation_resolution
         url = self._build_url("protection", base_url=self._api)
         resp = self._put(url, json=edit)
         json = self._json(resp, 200)

--- a/src/github3/repos/comment.py
+++ b/src/github3/repos/comment.py
@@ -1,4 +1,5 @@
 """This module contains the RepoComment class."""
+
 from .. import models, users
 from ..decorators import requires_auth
 

--- a/src/github3/repos/comment.py
+++ b/src/github3/repos/comment.py
@@ -1,6 +1,7 @@
 """This module contains the RepoComment class."""
 
-from .. import models, users
+from .. import models
+from .. import users
 from ..decorators import requires_auth
 
 

--- a/src/github3/repos/comment.py
+++ b/src/github3/repos/comment.py
@@ -1,6 +1,5 @@
 """This module contains the RepoComment class."""
-from .. import models
-from .. import users
+from .. import models, users
 from ..decorators import requires_auth
 
 

--- a/src/github3/repos/commit.py
+++ b/src/github3/repos/commit.py
@@ -1,6 +1,9 @@
 """This module contains the RepoCommit classes."""
 
-from .. import checks, git, models, users
+from .. import checks
+from .. import git
+from .. import models
+from .. import users
 from . import status
 from .comment import RepoComment
 

--- a/src/github3/repos/commit.py
+++ b/src/github3/repos/commit.py
@@ -1,9 +1,6 @@
 """This module contains the RepoCommit classes."""
+from .. import checks, git, models, users
 from . import status
-from .. import checks
-from .. import git
-from .. import models
-from .. import users
 from .comment import RepoComment
 
 

--- a/src/github3/repos/commit.py
+++ b/src/github3/repos/commit.py
@@ -1,4 +1,5 @@
 """This module contains the RepoCommit classes."""
+
 from .. import checks, git, models, users
 from . import status
 from .comment import RepoComment

--- a/src/github3/repos/comparison.py
+++ b/src/github3/repos/comparison.py
@@ -1,6 +1,6 @@
 """This module contains the Comparison object."""
-from . import commit
 from .. import models
+from . import commit
 
 
 class Comparison(models.GitHubCore):

--- a/src/github3/repos/comparison.py
+++ b/src/github3/repos/comparison.py
@@ -1,4 +1,5 @@
 """This module contains the Comparison object."""
+
 from .. import models
 from . import commit
 

--- a/src/github3/repos/contents.py
+++ b/src/github3/repos/contents.py
@@ -1,4 +1,5 @@
 """This module contains the Contents object."""
+
 from base64 import b64decode, b64encode
 from json import dumps
 

--- a/src/github3/repos/contents.py
+++ b/src/github3/repos/contents.py
@@ -1,6 +1,5 @@
 """This module contains the Contents object."""
-from base64 import b64decode
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from json import dumps
 
 from .. import models

--- a/src/github3/repos/contents.py
+++ b/src/github3/repos/contents.py
@@ -1,6 +1,7 @@
 """This module contains the Contents object."""
 
-from base64 import b64decode, b64encode
+from base64 import b64decode
+from base64 import b64encode
 from json import dumps
 
 from .. import models

--- a/src/github3/repos/deployment.py
+++ b/src/github3/repos/deployment.py
@@ -1,4 +1,5 @@
 """The module containing deployment logic."""
+
 from .. import users
 from ..models import GitHubCore
 

--- a/src/github3/repos/hook.py
+++ b/src/github3/repos/hook.py
@@ -1,4 +1,5 @@
 """This module contains only the Hook object for GitHub's Hook API."""
+
 from json import dumps
 
 from ..decorators import requires_auth

--- a/src/github3/repos/invitation.py
+++ b/src/github3/repos/invitation.py
@@ -1,4 +1,5 @@
 """Invitation related logic."""
+
 from json import dumps
 
 from .. import models, users

--- a/src/github3/repos/invitation.py
+++ b/src/github3/repos/invitation.py
@@ -1,8 +1,7 @@
 """Invitation related logic."""
 from json import dumps
 
-from .. import models
-from .. import users
+from .. import models, users
 from ..decorators import requires_auth
 
 

--- a/src/github3/repos/invitation.py
+++ b/src/github3/repos/invitation.py
@@ -2,7 +2,8 @@
 
 from json import dumps
 
-from .. import models, users
+from .. import models
+from .. import users
 from ..decorators import requires_auth
 
 

--- a/src/github3/repos/issue_import.py
+++ b/src/github3/repos/issue_import.py
@@ -1,4 +1,5 @@
 """This module contains the logic for GitHub's import issue API."""
+
 from .. import models
 
 

--- a/src/github3/repos/pages.py
+++ b/src/github3/repos/pages.py
@@ -1,4 +1,5 @@
 """GitHub Pages related logic."""
+
 from .. import models
 
 

--- a/src/github3/repos/release.py
+++ b/src/github3/repos/release.py
@@ -4,7 +4,9 @@ import json
 
 from uritemplate import URITemplate  # type: ignore
 
-from .. import models, users, utils
+from .. import models
+from .. import users
+from .. import utils
 from ..decorators import requires_auth
 from ..exceptions import error_for
 

--- a/src/github3/repos/release.py
+++ b/src/github3/repos/release.py
@@ -1,4 +1,5 @@
 """Release logic for the GitHub API."""
+
 import json
 
 from uritemplate import URITemplate  # type: ignore

--- a/src/github3/repos/release.py
+++ b/src/github3/repos/release.py
@@ -3,9 +3,7 @@ import json
 
 from uritemplate import URITemplate  # type: ignore
 
-from .. import models
-from .. import users
-from .. import utils
+from .. import models, users, utils
 from ..decorators import requires_auth
 from ..exceptions import error_for
 

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -4,6 +4,7 @@ The Repository objects represent various different repository representations
 returned by GitHub.
 
 """
+
 import base64
 import json as jsonlib
 

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -10,41 +10,38 @@ import json as jsonlib
 
 import uritemplate as urit  # type: ignore
 
-from .. import (
-    checks,
-    decorators,
-    events,
-    exceptions,
-    git,
-    issues,
-    licenses,
-    models,
-    notifications,
-    projects,
-    pulls,
-    users,
-    utils,
-)
+from .. import checks
+from .. import decorators
+from .. import events
+from .. import exceptions
+from .. import git
+from .. import issues
+from .. import licenses
+from .. import models
+from .. import notifications
+from .. import projects
+from .. import pulls
+from .. import users
+from .. import utils
 from ..issues import event as ievent
-from ..issues import label, milestone
-from . import (
-    branch,
-    comment,
-    commit,
-    comparison,
-    contents,
-    deployment,
-    hook,
-    invitation,
-    issue_import,
-    pages,
-    release,
-    stats,
-    status,
-    tag,
-    topics,
-    traffic,
-)
+from ..issues import label
+from ..issues import milestone
+from . import branch
+from . import comment
+from . import commit
+from . import comparison
+from . import contents
+from . import deployment
+from . import hook
+from . import invitation
+from . import issue_import
+from . import pages
+from . import release
+from . import stats
+from . import status
+from . import tag
+from . import topics
+from . import traffic
 
 
 class _Repository(models.GitHubCore):

--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -9,38 +9,41 @@ import json as jsonlib
 
 import uritemplate as urit  # type: ignore
 
-from . import branch
-from . import comment
-from . import commit
-from . import comparison
-from . import contents
-from . import deployment
-from . import hook
-from . import invitation
-from . import issue_import
-from . import pages
-from . import release
-from . import stats
-from . import status
-from . import tag
-from . import topics
-from . import traffic
-from .. import checks
-from .. import decorators
-from .. import events
-from .. import exceptions
-from .. import git
-from .. import issues
-from .. import licenses
-from .. import models
-from .. import notifications
-from .. import projects
-from .. import pulls
-from .. import users
-from .. import utils
+from .. import (
+    checks,
+    decorators,
+    events,
+    exceptions,
+    git,
+    issues,
+    licenses,
+    models,
+    notifications,
+    projects,
+    pulls,
+    users,
+    utils,
+)
 from ..issues import event as ievent
-from ..issues import label
-from ..issues import milestone
+from ..issues import label, milestone
+from . import (
+    branch,
+    comment,
+    commit,
+    comparison,
+    contents,
+    deployment,
+    hook,
+    invitation,
+    issue_import,
+    pages,
+    release,
+    stats,
+    status,
+    tag,
+    topics,
+    traffic,
+)
 
 
 class _Repository(models.GitHubCore):

--- a/src/github3/repos/stats.py
+++ b/src/github3/repos/stats.py
@@ -1,4 +1,5 @@
 """Repository and contributor stats logic."""
+
 import datetime
 
 import dateutil.tz

--- a/src/github3/repos/stats.py
+++ b/src/github3/repos/stats.py
@@ -4,7 +4,8 @@ import datetime
 
 import dateutil.tz
 
-from .. import models, users
+from .. import models
+from .. import users
 
 
 def alternate_week(week):

--- a/src/github3/repos/stats.py
+++ b/src/github3/repos/stats.py
@@ -3,8 +3,7 @@ import datetime
 
 import dateutil.tz
 
-from .. import models
-from .. import users
+from .. import models, users
 
 
 def alternate_week(week):

--- a/src/github3/repos/status.py
+++ b/src/github3/repos/status.py
@@ -1,4 +1,5 @@
 """This module contains the Status object for GitHub's commit status API."""
+
 from .. import models, users
 from ..models import GitHubCore
 

--- a/src/github3/repos/status.py
+++ b/src/github3/repos/status.py
@@ -1,6 +1,7 @@
 """This module contains the Status object for GitHub's commit status API."""
 
-from .. import models, users
+from .. import models
+from .. import users
 from ..models import GitHubCore
 
 

--- a/src/github3/repos/status.py
+++ b/src/github3/repos/status.py
@@ -1,6 +1,5 @@
 """This module contains the Status object for GitHub's commit status API."""
-from .. import models
-from .. import users
+from .. import models, users
 from ..models import GitHubCore
 
 

--- a/src/github3/repos/tag.py
+++ b/src/github3/repos/tag.py
@@ -1,4 +1,5 @@
 """This module contains the RepoTag object for GitHub's tag API."""
+
 from .. import models
 from . import commit
 

--- a/src/github3/repos/tag.py
+++ b/src/github3/repos/tag.py
@@ -1,6 +1,6 @@
 """This module contains the RepoTag object for GitHub's tag API."""
-from . import commit
 from .. import models
+from . import commit
 
 
 class RepoTag(models.GitHubCore):

--- a/src/github3/repos/topics.py
+++ b/src/github3/repos/topics.py
@@ -1,4 +1,5 @@
 """Topics related logic."""
+
 from .. import models
 
 

--- a/src/github3/repos/traffic.py
+++ b/src/github3/repos/traffic.py
@@ -1,4 +1,5 @@
 """Repository traffic stats logic."""
+
 from .. import models
 
 

--- a/src/github3/search/__init__.py
+++ b/src/github3/search/__init__.py
@@ -4,7 +4,6 @@ from .issue import IssueSearchResult
 from .repository import RepositorySearchResult
 from .user import UserSearchResult
 
-
 __all__ = (
     "CodeSearchResult",
     "CommitSearchResult",

--- a/src/github3/search/code.py
+++ b/src/github3/search/code.py
@@ -1,6 +1,7 @@
 """Code search results implementation."""
 
-from .. import models, repos
+from .. import models
+from .. import repos
 
 
 class CodeSearchResult(models.GitHubCore):

--- a/src/github3/search/code.py
+++ b/src/github3/search/code.py
@@ -1,4 +1,5 @@
 """Code search results implementation."""
+
 from .. import models, repos
 
 

--- a/src/github3/search/code.py
+++ b/src/github3/search/code.py
@@ -1,6 +1,5 @@
 """Code search results implementation."""
-from .. import models
-from .. import repos
+from .. import models, repos
 
 
 class CodeSearchResult(models.GitHubCore):

--- a/src/github3/search/commit.py
+++ b/src/github3/search/commit.py
@@ -1,6 +1,9 @@
 """Commit search results implementation."""
 
-from .. import git, models, repos, users
+from .. import git
+from .. import models
+from .. import repos
+from .. import users
 
 
 class CommitSearchResult(models.GitHubCore):

--- a/src/github3/search/commit.py
+++ b/src/github3/search/commit.py
@@ -1,4 +1,5 @@
 """Commit search results implementation."""
+
 from .. import git, models, repos, users
 
 

--- a/src/github3/search/commit.py
+++ b/src/github3/search/commit.py
@@ -1,8 +1,5 @@
 """Commit search results implementation."""
-from .. import git
-from .. import models
-from .. import repos
-from .. import users
+from .. import git, models, repos, users
 
 
 class CommitSearchResult(models.GitHubCore):

--- a/src/github3/search/issue.py
+++ b/src/github3/search/issue.py
@@ -1,4 +1,5 @@
 """Issue search results implementation."""
+
 from ..issues import ShortIssue
 from ..models import GitHubCore
 

--- a/src/github3/search/repository.py
+++ b/src/github3/search/repository.py
@@ -1,6 +1,7 @@
 """Repository search results implementation."""
 
-from .. import models, repos
+from .. import models
+from .. import repos
 
 
 class RepositorySearchResult(models.GitHubCore):

--- a/src/github3/search/repository.py
+++ b/src/github3/search/repository.py
@@ -1,6 +1,5 @@
 """Repository search results implementation."""
-from .. import models
-from .. import repos
+from .. import models, repos
 
 
 class RepositorySearchResult(models.GitHubCore):

--- a/src/github3/search/repository.py
+++ b/src/github3/search/repository.py
@@ -1,4 +1,5 @@
 """Repository search results implementation."""
+
 from .. import models, repos
 
 

--- a/src/github3/session.py
+++ b/src/github3/session.py
@@ -1,4 +1,5 @@
 """Module containing session and auth logic."""
+
 import collections.abc as abc_collections
 import datetime
 from contextlib import contextmanager

--- a/src/github3/structs.py
+++ b/src/github3/structs.py
@@ -155,7 +155,6 @@ class GitHubIterator(models.GitHubCore, collections.abc.Iterator):
 
 
 class SearchIterator(GitHubIterator):
-
     """This is a special-cased class for returning iterable search results.
 
     It inherits from :class:`GitHubIterator <github3.structs.GitHubIterator>`.

--- a/src/github3/structs.py
+++ b/src/github3/structs.py
@@ -2,11 +2,9 @@ import collections.abc
 import functools
 import typing as t
 
-from requests.compat import urlencode
-from requests.compat import urlparse
+from requests.compat import urlencode, urlparse
 
-from . import exceptions
-from . import models
+from . import exceptions, models
 
 if t.TYPE_CHECKING:
     import requests.models

--- a/src/github3/structs.py
+++ b/src/github3/structs.py
@@ -2,9 +2,11 @@ import collections.abc
 import functools
 import typing as t
 
-from requests.compat import urlencode, urlparse
+from requests.compat import urlencode
+from requests.compat import urlparse
 
-from . import exceptions, models
+from . import exceptions
+from . import models
 
 if t.TYPE_CHECKING:
     import requests.models

--- a/src/github3/users.py
+++ b/src/github3/users.py
@@ -1,4 +1,5 @@
 """This module contains everything relating to Users."""
+
 import typing as t
 from json import dumps
 

--- a/src/github3/users.py
+++ b/src/github3/users.py
@@ -4,10 +4,11 @@ from json import dumps
 
 from uritemplate import URITemplate  # type: ignore
 
+from github3.auths import Authorization
+
 from . import models
 from .decorators import requires_auth
 from .events import Event
-from github3.auths import Authorization
 
 
 class GPGKey(models.GitHubCore):

--- a/src/github3/users.py
+++ b/src/github3/users.py
@@ -504,7 +504,8 @@ class _User(models.GitHubCore):
             endpoint
         :returns: generator of :class:`~github3.repos.repo.StarredRepository`
         """
-        from .repos import Repository, StarredRepository
+        from .repos import Repository
+        from .repos import StarredRepository
 
         params = {"sort": sort, "direction": direction}
         self._remove_none(params)

--- a/src/github3/utils.py
+++ b/src/github3/utils.py
@@ -1,4 +1,5 @@
 """A collection of useful utilities."""
+
 import collections.abc as abc_collections
 import datetime
 import re

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,4 +1,5 @@
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_auths.py
+++ b/tests/integration/test_auths.py
@@ -1,11 +1,11 @@
 """Integration tests for the github3.auths module."""
+
 import github3
 
 from .helper import IntegrationHelper
 
 
 class TestAuthorization(IntegrationHelper):
-
     """Integration tests for the Authorization class."""
 
     def test_add_scopes(self):

--- a/tests/integration/test_auths.py
+++ b/tests/integration/test_auths.py
@@ -1,5 +1,6 @@
 """Integration tests for the github3.auths module."""
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_checks.py
+++ b/tests/integration/test_checks.py
@@ -5,6 +5,7 @@ import dateutil
 import pytest
 
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_checks.py
+++ b/tests/integration/test_checks.py
@@ -1,4 +1,5 @@
 """Integration tests for methods implemented on Check* classes."""
+
 import datetime
 
 import dateutil

--- a/tests/integration/test_gists.py
+++ b/tests/integration/test_gists.py
@@ -1,5 +1,6 @@
 """Integration tests for methods implemented on Gist."""
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_gists.py
+++ b/tests/integration/test_gists.py
@@ -1,11 +1,11 @@
 """Integration tests for methods implemented on Gist."""
+
 import github3
 
 from .helper import IntegrationHelper
 
 
 class TestGist(IntegrationHelper):
-
     """Gist integration tests."""
 
     def test_comments(self):

--- a/tests/integration/test_git.py
+++ b/tests/integration/test_git.py
@@ -1,11 +1,11 @@
 """Integration tests for Git."""
+
 import github3
 
 from .helper import IntegrationHelper
 
 
 class TestTree(IntegrationHelper):
-
     """Integration tests for methods on the Test class."""
 
     def test_inequality(self):
@@ -30,7 +30,6 @@ class TestTree(IntegrationHelper):
 
 
 class TestReference(IntegrationHelper):
-
     """Integration tests for methods on the Reference class."""
 
     def test_update(self):

--- a/tests/integration/test_git.py
+++ b/tests/integration/test_git.py
@@ -1,5 +1,6 @@
 """Integration tests for Git."""
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -1,4 +1,5 @@
 """Integration tests for methods implemented on GitHub."""
+
 from datetime import datetime
 
 import pytest

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -7,7 +7,8 @@ import uritemplate
 
 import github3
 
-from .helper import GitHubEnterpriseHelper, IntegrationHelper
+from .helper import GitHubEnterpriseHelper
+from .helper import IntegrationHelper
 
 GPG_KEY = (
     # Generated for this alone then deleted

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -5,8 +5,8 @@ import pytest
 import uritemplate
 
 import github3
-from .helper import GitHubEnterpriseHelper
-from .helper import IntegrationHelper
+
+from .helper import GitHubEnterpriseHelper, IntegrationHelper
 
 GPG_KEY = (
     # Generated for this alone then deleted

--- a/tests/integration/test_issue.py
+++ b/tests/integration/test_issue.py
@@ -1,4 +1,5 @@
 """Integration tests for Issues."""
+
 import pytest
 
 import github3
@@ -8,7 +9,6 @@ from .helper import IntegrationHelper
 
 
 class TestIssue(IntegrationHelper):
-
     """Integration tests for methods on the Issue class."""
 
     def test_add_assignees(self):

--- a/tests/integration/test_issue.py
+++ b/tests/integration/test_issue.py
@@ -3,6 +3,7 @@ import pytest
 
 import github3
 import github3.exceptions as exc
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_issues_milestone.py
+++ b/tests/integration/test_issues_milestone.py
@@ -1,4 +1,5 @@
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -1,4 +1,5 @@
 """Integration test for Notifications."""
+
 import github3
 
 from .helper import IntegrationHelper

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -1,5 +1,6 @@
 """Integration test for Notifications."""
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_orgs.py
+++ b/tests/integration/test_orgs.py
@@ -1,4 +1,5 @@
 """Integration tests for methods implemented on Organization."""
+
 import pytest
 
 import github3
@@ -7,7 +8,6 @@ from .helper import IntegrationHelper
 
 
 class TestOrganization(IntegrationHelper):
-
     """Organization integration tests."""
 
     betamax_kwargs = {"match_requests_on": ["method", "uri", "json-body"]}
@@ -421,7 +421,6 @@ class TestOrganization(IntegrationHelper):
 
 
 class TestOrganizationHook(IntegrationHelper):
-
     """Integration tests for OrganizationHook object."""
 
     def test_delete(self):

--- a/tests/integration/test_orgs.py
+++ b/tests/integration/test_orgs.py
@@ -2,6 +2,7 @@
 import pytest
 
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_orgs_team.py
+++ b/tests/integration/test_orgs_team.py
@@ -1,5 +1,6 @@
 """Integration tests for methods implemented on Team."""
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_orgs_team.py
+++ b/tests/integration/test_orgs_team.py
@@ -1,11 +1,11 @@
 """Integration tests for methods implemented on Team."""
+
 import github3
 
 from .helper import IntegrationHelper
 
 
 class TestTeam(IntegrationHelper):
-
     """Team integration tests."""
 
     betamax_kwargs = {"match_requests_on": ["method", "uri", "json-body"]}

--- a/tests/integration/test_projects.py
+++ b/tests/integration/test_projects.py
@@ -1,4 +1,5 @@
 """Integration tests for methods implemented on Project."""
+
 import github3
 
 from .helper import IntegrationHelper

--- a/tests/integration/test_projects.py
+++ b/tests/integration/test_projects.py
@@ -1,5 +1,6 @@
 """Integration tests for methods implemented on Project."""
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_pulls.py
+++ b/tests/integration/test_pulls.py
@@ -1,7 +1,8 @@
 """Integration tests for methods implemented on PullRequest."""
 import github3
-from .helper import IntegrationHelper
 from github3 import repos
+
+from .helper import IntegrationHelper
 
 
 class TestPullRequest(IntegrationHelper):

--- a/tests/integration/test_pulls.py
+++ b/tests/integration/test_pulls.py
@@ -1,4 +1,5 @@
 """Integration tests for methods implemented on PullRequest."""
+
 import github3
 from github3 import repos
 

--- a/tests/integration/test_repos_branch.py
+++ b/tests/integration/test_repos_branch.py
@@ -1,4 +1,5 @@
 """Integration tests for methods implemented on Branch."""
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_repos_commit.py
+++ b/tests/integration/test_repos_commit.py
@@ -1,5 +1,6 @@
 """Integration tests for Repository Commit objects."""
 import github3
+
 from . import helper
 
 

--- a/tests/integration/test_repos_commit.py
+++ b/tests/integration/test_repos_commit.py
@@ -1,4 +1,5 @@
 """Integration tests for Repository Commit objects."""
+
 import github3
 
 from . import helper

--- a/tests/integration/test_repos_deployment.py
+++ b/tests/integration/test_repos_deployment.py
@@ -1,4 +1,5 @@
 """Deployment integration tests."""
+
 import github3
 
 from .helper import IntegrationHelper
@@ -10,7 +11,6 @@ def find(func, iterable):
 
 
 class TestDeployment(IntegrationHelper):
-
     """Integration tests for the Deployment class."""
 
     def test_create_status(self):

--- a/tests/integration/test_repos_deployment.py
+++ b/tests/integration/test_repos_deployment.py
@@ -1,5 +1,6 @@
 """Deployment integration tests."""
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_repos_invitation.py
+++ b/tests/integration/test_repos_invitation.py
@@ -1,5 +1,6 @@
 """Integration tests for Repository Invitation objects."""
 import github3
+
 from . import helper
 
 

--- a/tests/integration/test_repos_invitation.py
+++ b/tests/integration/test_repos_invitation.py
@@ -1,4 +1,5 @@
 """Integration tests for Repository Invitation objects."""
+
 import github3
 
 from . import helper

--- a/tests/integration/test_repos_pages.py
+++ b/tests/integration/test_repos_pages.py
@@ -1,4 +1,5 @@
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_repos_release.py
+++ b/tests/integration/test_repos_release.py
@@ -4,6 +4,7 @@ import tempfile
 import pytest
 
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_repos_repo.py
+++ b/tests/integration/test_repos_repo.py
@@ -6,6 +6,7 @@ import pytest
 
 import github3
 import github3.exceptions as exc
+
 from . import helper
 
 

--- a/tests/integration/test_repos_repo.py
+++ b/tests/integration/test_repos_repo.py
@@ -1,4 +1,5 @@
 """Integration tests for Repositories."""
+
 import datetime
 import itertools
 
@@ -11,7 +12,6 @@ from . import helper
 
 
 class TestRepository(helper.IntegrationHelper):
-
     """Integration tests for the Repository object."""
 
     def test_add_collaborator(self):
@@ -1426,7 +1426,6 @@ class TestRepository(helper.IntegrationHelper):
 
 
 class TestContents(helper.IntegrationHelper):
-
     """Integration test for Contents object."""
 
     def test_delete(self):
@@ -1463,7 +1462,6 @@ class TestContents(helper.IntegrationHelper):
 
 
 class TestHook(helper.IntegrationHelper):
-
     """Integration tests for Hook object."""
 
     def test_delete(self):
@@ -1545,7 +1543,6 @@ class TestHook(helper.IntegrationHelper):
 
 
 class TestRepoComment(helper.IntegrationHelper):
-
     """Integration tests for RepoComment object."""
 
     def test_delete(self):
@@ -1578,7 +1575,6 @@ class TestRepoComment(helper.IntegrationHelper):
 
 
 class TestRepoCommit(helper.IntegrationHelper):
-
     """Integration tests for RepoCommit object."""
 
     @pytest.mark.xfail
@@ -1609,7 +1605,6 @@ class TestRepoCommit(helper.IntegrationHelper):
 
 
 class TestComparison(helper.IntegrationHelper):
-
     """Integration test for Comparison object."""
 
     @pytest.mark.xfail

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -1,4 +1,5 @@
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_structs.py
+++ b/tests/integration/test_structs.py
@@ -1,6 +1,7 @@
 import pytest
 
 import github3
+
 from .helper import IntegrationHelper
 
 

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -1,4 +1,5 @@
 """Integration tests for the User class."""
+
 import datetime
 
 import pytest
@@ -35,7 +36,6 @@ GPG_KEY = (
 
 
 class TestGPGKey(IntegrationHelper):
-
     """Integration tests for methods of the GPGKey class."""
 
     def test_delete(self):
@@ -80,7 +80,6 @@ class TestKey(IntegrationHelper):
 
 
 class TestUser(IntegrationHelper):
-
     """Integration tests for methods on the User class."""
 
     def test_events(self):

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -4,8 +4,9 @@ import datetime
 import pytest
 
 import github3
-from .helper import IntegrationHelper
 from github3.exceptions import MethodNotAllowed
+
+from .helper import IntegrationHelper
 
 GPG_KEY = (
     # Generated for this alone then deleted

--- a/tests/unit/helper.py
+++ b/tests/unit/helper.py
@@ -1,4 +1,5 @@
 """Base classes and helpers for unit tests."""
+
 import json
 import os.path
 import sys
@@ -194,7 +195,6 @@ class UnitHelper(unittest.TestCase):
 
 
 class UnitIteratorHelper(UnitHelper):
-
     """Base class for iterator based unit tests."""
 
     def create_session_mock(self, *args):
@@ -255,7 +255,6 @@ class UnitIteratorAppInstHelper(UnitIteratorHelper):
 
 
 class UnitSearchIteratorHelper(UnitIteratorHelper):
-
     """Base class for search iterator based unit tests."""
 
     def patch_get_json(self):
@@ -284,7 +283,6 @@ class UnitAppInstallHelper(UnitHelper):
 
 
 class UnitRequiresAuthenticationHelper(UnitHelper):
-
     """Helper for unit tests that demonstrate authentication is required."""
 
     def after_setup(self):

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,11 +1,11 @@
 """Unit tests for github3.api."""
+
 import unittest.mock
 
 import github3
 
 
 class TestAPI(unittest.TestCase):
-
     """All tests for the github3.api module."""
 
     def test_enterprise_login(self):

--- a/tests/unit/test_auths.py
+++ b/tests/unit/test_auths.py
@@ -1,4 +1,5 @@
 """Unit tests for the auths module."""
+
 import github3
 
 from . import helper
@@ -7,7 +8,6 @@ url_for = helper.create_url_helper("https://api.github.com/authorizations/1")
 
 
 class TestAuthorization(helper.UnitHelper):
-
     """Authorization unit tests."""
 
     described_class = github3.auths.Authorization
@@ -52,7 +52,6 @@ class TestAuthorization(helper.UnitHelper):
 
 
 class TestAuthorizationRequiresAuth(helper.UnitRequiresAuthenticationHelper):
-
     """Test methods that require authentication on Authorization."""
 
     described_class = github3.auths.Authorization

--- a/tests/unit/test_auths.py
+++ b/tests/unit/test_auths.py
@@ -1,5 +1,6 @@
 """Unit tests for the auths module."""
 import github3
+
 from . import helper
 
 url_for = helper.create_url_helper("https://api.github.com/authorizations/1")

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -4,15 +4,17 @@ from json import dumps
 import pytest
 
 import github3
-from .helper import create_example_data_helper
-from .helper import create_url_helper
-from .helper import UnitAppInstallHelper
-from .helper import UnitHelper
-from .helper import UnitIteratorHelper
-from .helper import UnitRequiresAuthenticationHelper
-from github3.checks import CheckRun
-from github3.checks import CheckSuite
+from github3.checks import CheckRun, CheckSuite
 from github3.exceptions import GitHubException
+
+from .helper import (
+    UnitAppInstallHelper,
+    UnitHelper,
+    UnitIteratorHelper,
+    UnitRequiresAuthenticationHelper,
+    create_example_data_helper,
+    create_url_helper,
+)
 
 url_for = create_url_helper("https://api.github.com/repos/github/hello-world")
 

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -5,17 +5,16 @@ from json import dumps
 import pytest
 
 import github3
-from github3.checks import CheckRun, CheckSuite
+from github3.checks import CheckRun
+from github3.checks import CheckSuite
 from github3.exceptions import GitHubException
 
-from .helper import (
-    UnitAppInstallHelper,
-    UnitHelper,
-    UnitIteratorHelper,
-    UnitRequiresAuthenticationHelper,
-    create_example_data_helper,
-    create_url_helper,
-)
+from .helper import UnitAppInstallHelper
+from .helper import UnitHelper
+from .helper import UnitIteratorHelper
+from .helper import UnitRequiresAuthenticationHelper
+from .helper import create_example_data_helper
+from .helper import create_url_helper
 
 url_for = create_url_helper("https://api.github.com/repos/github/hello-world")
 

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -1,4 +1,5 @@
 """Unit tests around github3's Checks classes."""
+
 from json import dumps
 
 import pytest

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
 import github3
-from .helper import create_example_data_helper
-from .helper import UnitHelper
+
+from .helper import UnitHelper, create_example_data_helper
 
 get_example_data = create_example_data_helper("event_example")
 get_org_example_data = create_example_data_helper("org_example")

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 
 import github3
 
-from .helper import UnitHelper, create_example_data_helper
+from .helper import UnitHelper
+from .helper import create_example_data_helper
 
 get_example_data = create_example_data_helper("event_example")
 get_org_example_data = create_example_data_helper("org_example")

--- a/tests/unit/test_gists.py
+++ b/tests/unit/test_gists.py
@@ -1,4 +1,5 @@
 """Unit tests for the github3.gists module."""
+
 import pytest
 
 import github3
@@ -108,7 +109,6 @@ class TestGist(helper.UnitHelper):
 
 
 class TestGistIssue883(helper.UnitHelper):
-
     """Unit tests for the Gist object about issue 883."""
 
     described_class = github3.gists.Gist

--- a/tests/unit/test_gists.py
+++ b/tests/unit/test_gists.py
@@ -2,6 +2,7 @@
 import pytest
 
 import github3
+
 from . import helper
 
 gist_example_data = helper.create_example_data_helper("gist_example")

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -1,6 +1,8 @@
 import github3
 
-from .helper import UnitHelper, create_example_data_helper, create_url_helper
+from .helper import UnitHelper
+from .helper import create_example_data_helper
+from .helper import create_url_helper
 
 get_example_data = create_example_data_helper("tree_example")
 url_for = create_url_helper(

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -1,7 +1,6 @@
 import github3
-from .helper import create_example_data_helper
-from .helper import create_url_helper
-from .helper import UnitHelper
+
+from .helper import UnitHelper, create_example_data_helper, create_url_helper
 
 get_example_data = create_example_data_helper("tree_example")
 url_for = create_url_helper(

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -50,7 +50,6 @@ class TestTree(UnitHelper):
 
 
 class TestCommit(UnitHelper):
-
     """Commit unit test."""
 
     described_class = github3.git.Commit
@@ -61,7 +60,6 @@ class TestCommit(UnitHelper):
 
 
 class TestGitTag(UnitHelper):
-
     """Git Tag unit test."""
 
     described_class = github3.git.Tag
@@ -72,7 +70,6 @@ class TestGitTag(UnitHelper):
 
 
 class TestReference(UnitHelper):
-
     """Reference unit test."""
 
     described_class = github3.git.Reference

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -1308,7 +1308,6 @@ class TestGitHubIterators(helper.UnitIteratorHelper):
 
 
 class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
-
     """Test GitHub methods that return search iterators."""
 
     described_class = GitHub
@@ -1418,7 +1417,6 @@ class TestGitHubSearchIterators(helper.UnitSearchIteratorHelper):
 class TestGitHubRequiresAuthentication(
     helper.UnitRequiresAuthenticationHelper
 ):
-
     """Test methods that require authentication."""
 
     described_class = GitHub

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -2,11 +2,11 @@ import unittest.mock
 
 import pytest
 
-from . import helper
-from github3 import GitHubEnterprise
-from github3 import GitHubError
+from github3 import GitHubEnterprise, GitHubError
 from github3.github import GitHub
 from github3.projects import Project
+
+from . import helper
 
 
 def url_for(path=""):

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -2,7 +2,8 @@ import unittest.mock
 
 import pytest
 
-from github3 import GitHubEnterprise, GitHubError
+from github3 import GitHubEnterprise
+from github3 import GitHubError
 from github3.github import GitHub
 from github3.projects import Project
 

--- a/tests/unit/test_github_enterprise.py
+++ b/tests/unit/test_github_enterprise.py
@@ -1,7 +1,7 @@
 import github3
-from .helper import create_example_data_helper
-from .helper import UnitHelper
 from github3.github import GitHubEnterprise
+
+from .helper import UnitHelper, create_example_data_helper
 
 get_example_user = create_example_data_helper("user_example")
 

--- a/tests/unit/test_github_enterprise.py
+++ b/tests/unit/test_github_enterprise.py
@@ -1,7 +1,8 @@
 import github3
 from github3.github import GitHubEnterprise
 
-from .helper import UnitHelper, create_example_data_helper
+from .helper import UnitHelper
+from .helper import create_example_data_helper
 
 get_example_user = create_example_data_helper("user_example")
 

--- a/tests/unit/test_github_session.py
+++ b/tests/unit/test_github_session.py
@@ -6,7 +6,6 @@ except ImportError:
     import pickle
 
 import pytest
-
 import requests
 
 from github3 import session

--- a/tests/unit/test_issues_issue.py
+++ b/tests/unit/test_issues_issue.py
@@ -1,4 +1,5 @@
 """Unit tests for the Issue class."""
+
 import unittest.mock
 
 import dateutil.parser

--- a/tests/unit/test_issues_issue.py
+++ b/tests/unit/test_issues_issue.py
@@ -4,9 +4,10 @@ import unittest.mock
 import dateutil.parser
 
 import github3
-from . import helper
 from github3.issues import Issue
 from github3.issues.label import Label
+
+from . import helper
 
 comment_url_for = helper.create_url_helper(
     "https://api.github.com/repos/octocat/Hello-World/issues/comments"

--- a/tests/unit/test_issues_milestone.py
+++ b/tests/unit/test_issues_milestone.py
@@ -2,6 +2,7 @@
 import datetime
 
 import github3
+
 from . import helper
 
 get_milestone_example_data = helper.create_example_data_helper(

--- a/tests/unit/test_issues_milestone.py
+++ b/tests/unit/test_issues_milestone.py
@@ -1,4 +1,5 @@
 """Unit tests for the Milestone class."""
+
 import datetime
 
 import github3
@@ -93,7 +94,6 @@ class TestMilestone(helper.UnitHelper):
 
 
 class TestMilestoneIterator(helper.UnitIteratorHelper):
-
     """Test Milestone methods that return iterators."""
 
     described_class = github3.issues.milestone.Milestone

--- a/tests/unit/test_licenses.py
+++ b/tests/unit/test_licenses.py
@@ -1,7 +1,6 @@
 import github3
-from .helper import create_example_data_helper
-from .helper import create_url_helper
-from .helper import UnitHelper
+
+from .helper import UnitHelper, create_example_data_helper, create_url_helper
 
 get_example_data = create_example_data_helper("license_example")
 url_for = create_url_helper("https://api.github.com/licenses/mit")

--- a/tests/unit/test_licenses.py
+++ b/tests/unit/test_licenses.py
@@ -1,6 +1,8 @@
 import github3
 
-from .helper import UnitHelper, create_example_data_helper, create_url_helper
+from .helper import UnitHelper
+from .helper import create_example_data_helper
+from .helper import create_url_helper
 
 get_example_data = create_example_data_helper("license_example")
 url_for = create_url_helper("https://api.github.com/licenses/mit")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,17 +1,16 @@
 import io
 import json
 from copy import copy
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest import TestCase
 
 import pytest
 import requests
 
-from . import helper
-from github3 import exceptions
-from github3 import GitHubError
+from github3 import GitHubError, exceptions
 from github3.models import GitHubCore
+
+from . import helper
 
 
 class MyTestRefreshClass(GitHubCore):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,13 +1,15 @@
 import io
 import json
 from copy import copy
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from unittest import TestCase
 
 import pytest
 import requests
 
-from github3 import GitHubError, exceptions
+from github3 import GitHubError
+from github3 import exceptions
 from github3.models import GitHubCore
 
 from . import helper

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,4 +1,5 @@
 """Unit tests around the Thread class."""
+
 import github3
 
 from .helper import UnitHelper, create_example_data_helper, create_url_helper

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,8 +1,7 @@
 """Unit tests around the Thread class."""
 import github3
-from .helper import create_example_data_helper
-from .helper import create_url_helper
-from .helper import UnitHelper
+
+from .helper import UnitHelper, create_example_data_helper, create_url_helper
 
 get_example_data = create_example_data_helper("notification_example")
 url_for = create_url_helper("https://api.github.com/notifications/threads/1")

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -2,7 +2,9 @@
 
 import github3
 
-from .helper import UnitHelper, create_example_data_helper, create_url_helper
+from .helper import UnitHelper
+from .helper import create_example_data_helper
+from .helper import create_url_helper
 
 get_example_data = create_example_data_helper("notification_example")
 url_for = create_url_helper("https://api.github.com/notifications/threads/1")

--- a/tests/unit/test_orgs.py
+++ b/tests/unit/test_orgs.py
@@ -3,7 +3,8 @@
 import pytest
 
 from github3 import GitHubError
-from github3.orgs import Organization, OrganizationHook
+from github3.orgs import Organization
+from github3.orgs import OrganizationHook
 from github3.projects import Project
 
 from . import helper

--- a/tests/unit/test_orgs.py
+++ b/tests/unit/test_orgs.py
@@ -1,11 +1,11 @@
 """Organization unit tests."""
 import pytest
 
-from . import helper
 from github3 import GitHubError
-from github3.orgs import Organization
-from github3.orgs import OrganizationHook
+from github3.orgs import Organization, OrganizationHook
 from github3.projects import Project
+
+from . import helper
 
 url_for = helper.create_url_helper("https://api.github.com/orgs/github")
 hook_url_for = helper.create_url_helper(

--- a/tests/unit/test_orgs.py
+++ b/tests/unit/test_orgs.py
@@ -1,4 +1,5 @@
 """Organization unit tests."""
+
 import pytest
 
 from github3 import GitHubError

--- a/tests/unit/test_orgs_team.py
+++ b/tests/unit/test_orgs_team.py
@@ -1,8 +1,9 @@
 import pytest
 
-from . import helper
 from github3 import GitHubError
 from github3.orgs import Team
+
+from . import helper
 
 url_for = helper.create_url_helper(
     "https://api.github.com/organizations/1/team/1"

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1,4 +1,5 @@
 """Unit tests for the github3.projects module."""
+
 import pytest
 
 from github3 import GitHubError, exceptions, issues, projects

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from github3 import GitHubError, exceptions, issues, projects
+from github3 import GitHubError
+from github3 import exceptions
+from github3 import issues
+from github3 import projects
 
 from . import helper
 

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1,12 +1,9 @@
 """Unit tests for the github3.projects module."""
 import pytest
 
-from . import helper
-from github3 import exceptions
-from github3 import GitHubError
-from github3 import issues
-from github3 import projects
+from github3 import GitHubError, exceptions, issues, projects
 
+from . import helper
 
 get_project_example_data = helper.create_example_data_helper(
     "project_example"

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -1,9 +1,9 @@
 """Unit tests for the github3.pulls module."""
 import pytest
 
+from github3 import GitHubError, pulls
+
 from . import helper
-from github3 import GitHubError
-from github3 import pulls
 
 get_pr_example_data = helper.create_example_data_helper(
     "pull_request_example"

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -1,4 +1,5 @@
 """Unit tests for the github3.pulls module."""
+
 import pytest
 
 from github3 import GitHubError, pulls

--- a/tests/unit/test_pulls.py
+++ b/tests/unit/test_pulls.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from github3 import GitHubError, pulls
+from github3 import GitHubError
+from github3 import pulls
 
 from . import helper
 

--- a/tests/unit/test_repos_branch.py
+++ b/tests/unit/test_repos_branch.py
@@ -1,4 +1,5 @@
 """Unit tests for methods implemented on Branch."""
+
 import github3
 
 from . import helper
@@ -38,7 +39,6 @@ class TestBranch(helper.UnitHelper):
 
 
 class TestBranchRequiresAuth(helper.UnitRequiresAuthenticationHelper):
-
     """Unit tests for Branch methods that require authentication."""
 
     described_class = github3.repos.branch.Branch

--- a/tests/unit/test_repos_branch.py
+++ b/tests/unit/test_repos_branch.py
@@ -1,5 +1,6 @@
 """Unit tests for methods implemented on Branch."""
 import github3
+
 from . import helper
 
 get_example_data = helper.create_example_data_helper("repos_branch_example")

--- a/tests/unit/test_repos_branch_protection.py
+++ b/tests/unit/test_repos_branch_protection.py
@@ -1,5 +1,6 @@
 """Unit tests for methods implemented on Branch Protection."""
 import github3
+
 from . import helper
 
 protection_example_data = helper.create_example_data_helper(

--- a/tests/unit/test_repos_branch_protection.py
+++ b/tests/unit/test_repos_branch_protection.py
@@ -1,4 +1,5 @@
 """Unit tests for methods implemented on Branch Protection."""
+
 import github3
 
 from . import helper

--- a/tests/unit/test_repos_commit.py
+++ b/tests/unit/test_repos_commit.py
@@ -1,5 +1,6 @@
 """Unit tests for Repository Commits."""
 import github3
+
 from . import helper
 
 get_commit_example_data = helper.create_example_data_helper("commit_example")

--- a/tests/unit/test_repos_commit.py
+++ b/tests/unit/test_repos_commit.py
@@ -1,4 +1,5 @@
 """Unit tests for Repository Commits."""
+
 import github3
 
 from . import helper
@@ -10,7 +11,6 @@ url_for = helper.create_url_helper(example_commit_data["url"])
 
 
 class TestRepoCommitIterator(helper.UnitIteratorHelper):
-
     """Unit tests for RepoCommit iterator methods."""
 
     described_class = github3.repos.commit.RepoCommit
@@ -47,7 +47,6 @@ class TestRepoCommitIterator(helper.UnitIteratorHelper):
 
 
 class TestRepoCommitIteratorAppInstAuth(helper.UnitIteratorAppInstHelper):
-
     """Unit tests for RepoCommit iterator methods."""
 
     described_class = github3.repos.commit.RepoCommit

--- a/tests/unit/test_repos_deployment.py
+++ b/tests/unit/test_repos_deployment.py
@@ -2,11 +2,9 @@
 
 import github3
 
-from .helper import (
-    UnitIteratorHelper,
-    create_example_data_helper,
-    create_url_helper,
-)
+from .helper import UnitIteratorHelper
+from .helper import create_example_data_helper
+from .helper import create_url_helper
 
 url_for = create_url_helper(
     "https://api.github.com/repos/octocat/example/deployments/1"

--- a/tests/unit/test_repos_deployment.py
+++ b/tests/unit/test_repos_deployment.py
@@ -1,8 +1,7 @@
 """Unit tests for Deployment methods."""
 import github3
-from .helper import create_example_data_helper
-from .helper import create_url_helper
-from .helper import UnitIteratorHelper
+
+from .helper import UnitIteratorHelper, create_example_data_helper, create_url_helper
 
 url_for = create_url_helper(
     "https://api.github.com/repos/octocat/example/deployments/1"

--- a/tests/unit/test_repos_deployment.py
+++ b/tests/unit/test_repos_deployment.py
@@ -1,7 +1,11 @@
 """Unit tests for Deployment methods."""
 import github3
 
-from .helper import UnitIteratorHelper, create_example_data_helper, create_url_helper
+from .helper import (
+    UnitIteratorHelper,
+    create_example_data_helper,
+    create_url_helper,
+)
 
 url_for = create_url_helper(
     "https://api.github.com/repos/octocat/example/deployments/1"

--- a/tests/unit/test_repos_deployment.py
+++ b/tests/unit/test_repos_deployment.py
@@ -1,4 +1,5 @@
 """Unit tests for Deployment methods."""
+
 import github3
 
 from .helper import (
@@ -17,7 +18,6 @@ example_data = get_repo_example_data()
 
 
 class TestDeploymentIterators(UnitIteratorHelper):
-
     """Test Deployment methods that return iterators."""
 
     described_class = github3.repos.deployment.Deployment

--- a/tests/unit/test_repos_invitation.py
+++ b/tests/unit/test_repos_invitation.py
@@ -1,4 +1,5 @@
 """Unit tests for Repository Invitation objects."""
+
 import github3
 
 from . import helper

--- a/tests/unit/test_repos_invitation.py
+++ b/tests/unit/test_repos_invitation.py
@@ -1,5 +1,6 @@
 """Unit tests for Repository Invitation objects."""
 import github3
+
 from . import helper
 
 get_invitation_example_data = helper.create_example_data_helper(

--- a/tests/unit/test_repos_release.py
+++ b/tests/unit/test_repos_release.py
@@ -4,13 +4,15 @@ import unittest.mock
 import pytest
 
 import github3
-from .helper import create_example_data_helper
-from .helper import create_url_helper
-from .helper import UnitHelper
-from .helper import UnitIteratorHelper
-from github3.repos.release import Asset
-from github3.repos.release import Release
+from github3.repos.release import Asset, Release
 from github3.users import ShortUser
+
+from .helper import (
+    UnitHelper,
+    UnitIteratorHelper,
+    create_example_data_helper,
+    create_url_helper,
+)
 
 url_for = create_url_helper(
     "https://api.github.com/repos/sigmavirus24/github3.py/releases"

--- a/tests/unit/test_repos_release.py
+++ b/tests/unit/test_repos_release.py
@@ -110,7 +110,6 @@ class TestRelease(UnitHelper):
 
 
 class TestReleaseIterators(UnitIteratorHelper):
-
     """Test iterator methods on the Release class."""
 
     described_class = Release

--- a/tests/unit/test_repos_release.py
+++ b/tests/unit/test_repos_release.py
@@ -4,15 +4,14 @@ import unittest.mock
 import pytest
 
 import github3
-from github3.repos.release import Asset, Release
+from github3.repos.release import Asset
+from github3.repos.release import Release
 from github3.users import ShortUser
 
-from .helper import (
-    UnitHelper,
-    UnitIteratorHelper,
-    create_example_data_helper,
-    create_url_helper,
-)
+from .helper import UnitHelper
+from .helper import UnitIteratorHelper
+from .helper import create_example_data_helper
+from .helper import create_url_helper
 
 url_for = create_url_helper(
     "https://api.github.com/repos/sigmavirus24/github3.py/releases"

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -1,4 +1,5 @@
 """Unit tests for Repositories."""
+
 import datetime
 import unittest.mock
 from base64 import b64encode
@@ -67,7 +68,6 @@ repo_2_12_example_data = get_repo_2_12_example_data()
 
 
 class TestRepository(helper.UnitHelper):
-
     """Unit test for regular Repository methods."""
 
     described_class = Repository
@@ -1026,7 +1026,6 @@ class TestRepository(helper.UnitHelper):
 
 
 class TestRepositoryIterator(helper.UnitIteratorHelper):
-
     """Unit tests for Repository methods that return iterators."""
 
     described_class = Repository
@@ -1468,7 +1467,6 @@ class TestRepositoryIterator(helper.UnitIteratorHelper):
 
 
 class TestRepositoryWithAppInstAuth(helper.UnitAppInstallHelper):
-
     """Unit test for regular Repository methods."""
 
     described_class = Repository
@@ -1507,7 +1505,6 @@ class TestRepositoryWithAppInstAuth(helper.UnitAppInstallHelper):
 
 
 class TestRepositoryRequiresAuth(helper.UnitRequiresAuthenticationHelper):
-
     """Unit test for regular Repository methods."""
 
     described_class = Repository
@@ -1768,7 +1765,6 @@ class TestContents(helper.UnitHelper):
 
 
 class TestContentsRequiresAuth(helper.UnitRequiresAuthenticationHelper):
-
     """Unit test for Content methods that require Auth."""
 
     described_class = Contents
@@ -1789,7 +1785,6 @@ class TestContentsRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
 
 class TestHook(helper.UnitHelper):
-
     """Test methods on Hook class."""
 
     described_class = Hook
@@ -1843,7 +1838,6 @@ class TestHook(helper.UnitHelper):
 
 
 class TestHookRequiresAuth(helper.UnitRequiresAuthenticationHelper):
-
     """Test methods on Hook object that require authentication."""
 
     described_class = Hook
@@ -1876,7 +1870,6 @@ class TestHookRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
 
 class TestRepoComment(helper.UnitHelper):
-
     """Unit test for methods on RepoComment object."""
 
     example_data = comment_example_data
@@ -1901,7 +1894,6 @@ class TestRepoComment(helper.UnitHelper):
 
 
 class TestRepoCommentRequiresAuth(helper.UnitRequiresAuthenticationHelper):
-
     """
     Unit test for methods that require authentication on RepoCommment
     object.
@@ -1926,7 +1918,6 @@ class TestRepoCommentRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
 
 class TestRepoCommit(helper.UnitHelper):
-
     """Unit tests for RepoCommit object."""
 
     described_class = RepoCommit
@@ -1959,7 +1950,6 @@ class TestRepoCommit(helper.UnitHelper):
 
 
 class TestComparison(helper.UnitHelper):
-
     """Unit test for Comparison object."""
 
     described_class = Comparison
@@ -1989,7 +1979,6 @@ class TestComparison(helper.UnitHelper):
 
 
 class TestRepositoryCompatibility_2_12(helper.UnitIteratorHelper):
-
     """Unit tests for Repository from Github Enterprise 2.12"""
 
     described_class = Repository

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -15,7 +15,8 @@ from github3.repos.commit import RepoCommit
 from github3.repos.comparison import Comparison
 from github3.repos.contents import Contents
 from github3.repos.hook import Hook
-from github3.repos.repo import Repository, ShortRepository
+from github3.repos.repo import Repository
+from github3.repos.repo import ShortRepository
 
 from . import helper
 

--- a/tests/unit/test_repos_repo.py
+++ b/tests/unit/test_repos_repo.py
@@ -5,7 +5,6 @@ from base64 import b64encode
 
 import pytest
 
-from . import helper
 from github3 import GitHubError
 from github3.exceptions import GitHubException
 from github3.models import GitHubCore
@@ -15,8 +14,9 @@ from github3.repos.commit import RepoCommit
 from github3.repos.comparison import Comparison
 from github3.repos.contents import Contents
 from github3.repos.hook import Hook
-from github3.repos.repo import Repository
-from github3.repos.repo import ShortRepository
+from github3.repos.repo import Repository, ShortRepository
+
+from . import helper
 
 comment_url_for = helper.create_url_helper(
     "https://api.github.com/repos/octocat/Hello-World/comments/1"

--- a/tests/unit/test_repos_status.py
+++ b/tests/unit/test_repos_status.py
@@ -8,7 +8,6 @@ get_combined_status_example_data = create_example_data_helper(
 
 
 class TestCombinedStatus(UnitHelper):
-
     """Commit unit test."""
 
     described_class = github3.repos.status.CombinedStatus

--- a/tests/unit/test_repos_status.py
+++ b/tests/unit/test_repos_status.py
@@ -1,6 +1,6 @@
 import github3
-from .helper import create_example_data_helper
-from .helper import UnitHelper
+
+from .helper import UnitHelper, create_example_data_helper
 
 get_combined_status_example_data = create_example_data_helper(
     "repos_combined_status_example"

--- a/tests/unit/test_repos_status.py
+++ b/tests/unit/test_repos_status.py
@@ -1,6 +1,7 @@
 import github3
 
-from .helper import UnitHelper, create_example_data_helper
+from .helper import UnitHelper
+from .helper import create_example_data_helper
 
 get_combined_status_example_data = create_example_data_helper(
     "repos_combined_status_example"

--- a/tests/unit/test_structs.py
+++ b/tests/unit/test_structs.py
@@ -1,7 +1,8 @@
 import unittest.mock
 
-from .helper import UnitHelper
 from github3.structs import GitHubIterator
+
+from .helper import UnitHelper
 
 
 class TestGitHubIterator(UnitHelper):

--- a/tests/unit/test_subscription.py
+++ b/tests/unit/test_subscription.py
@@ -1,8 +1,7 @@
 """Unit tests around github3's Subscription classes."""
 import github3
-from .helper import create_example_data_helper
-from .helper import create_url_helper
-from .helper import UnitHelper
+
+from .helper import UnitHelper, create_example_data_helper, create_url_helper
 
 get_example_data = create_example_data_helper("subscription_example")
 url_for = create_url_helper(

--- a/tests/unit/test_subscription.py
+++ b/tests/unit/test_subscription.py
@@ -2,7 +2,9 @@
 
 import github3
 
-from .helper import UnitHelper, create_example_data_helper, create_url_helper
+from .helper import UnitHelper
+from .helper import create_example_data_helper
+from .helper import create_url_helper
 
 get_example_data = create_example_data_helper("subscription_example")
 url_for = create_url_helper(

--- a/tests/unit/test_subscription.py
+++ b/tests/unit/test_subscription.py
@@ -1,4 +1,5 @@
 """Unit tests around github3's Subscription classes."""
+
 import github3
 
 from .helper import UnitHelper, create_example_data_helper, create_url_helper

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -1,6 +1,7 @@
 import pytest
 
 import github3
+
 from . import helper
 
 url_for = helper.create_url_helper("https://api.github.com/users/octocat")

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -34,7 +34,6 @@ authenticated_user_2_12_example_data = (
 
 
 class TestUser(helper.UnitHelper):
-
     """Test methods on User class."""
 
     described_class = github3.users.User
@@ -69,7 +68,6 @@ class TestUser(helper.UnitHelper):
 
 
 class TestUserGPGKeyRequiresAuth(helper.UnitRequiresAuthenticationHelper):
-
     """Unit tests that demonstrate which GPGKey methods require auth."""
 
     described_class = github3.users.GPGKey
@@ -81,7 +79,6 @@ class TestUserGPGKeyRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
 
 class TestUserGPGKey(helper.UnitHelper):
-
     """Unit tests for the GPGKey object."""
 
     described_class = github3.users.GPGKey
@@ -95,7 +92,6 @@ class TestUserGPGKey(helper.UnitHelper):
 
 
 class TestUserKeyRequiresAuth(helper.UnitRequiresAuthenticationHelper):
-
     """Test that ensure certain methods on Key class requires auth."""
 
     described_class = github3.users.Key
@@ -113,7 +109,6 @@ class TestUserKeyRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
 
 class TestUserKey(helper.UnitHelper):
-
     """Test methods on Key class."""
 
     described_class = github3.users.Key
@@ -145,7 +140,6 @@ class TestUserKey(helper.UnitHelper):
 
 
 class TestUserIterators(helper.UnitIteratorHelper):
-
     """Test User methods that return iterators."""
 
     described_class = github3.users.User
@@ -265,7 +259,6 @@ class TestUserIterators(helper.UnitIteratorHelper):
 
 
 class TestUsersRequiresAuth(helper.UnitRequiresAuthenticationHelper):
-
     """Test that ensure certain methods on the User class requires auth."""
 
     described_class = github3.users.User
@@ -278,7 +271,6 @@ class TestUsersRequiresAuth(helper.UnitRequiresAuthenticationHelper):
 
 
 class TestPlan(helper.UnitHelper):
-
     """Test for methods on Plan class."""
 
     described_class = github3.users.Plan
@@ -295,7 +287,6 @@ class TestPlan(helper.UnitHelper):
 
 
 class TestAuthenticatedUserCompatibility_2_12(helper.UnitHelper):
-
     """Test methods on AuthenticatedUser from Github Enterprise 2.12."""
 
     described_class = github3.users.AuthenticatedUser

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,8 +5,7 @@ from datetime import datetime
 import pytest
 import requests
 
-from github3.utils import stream_response_to_file
-from github3.utils import timestamp_parameter
+from github3.utils import stream_response_to_file, timestamp_parameter
 
 
 class TestTimestampConverter:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,7 +5,8 @@ from datetime import datetime
 import pytest
 import requests
 
-from github3.utils import stream_response_to_file, timestamp_parameter
+from github3.utils import stream_response_to_file
+from github3.utils import timestamp_parameter
 
 
 class TestTimestampConverter:

--- a/tox.ini
+++ b/tox.ini
@@ -119,3 +119,6 @@ ignore-path-errors = docs/source/release-notes/1.0.0.rst;D001
 extend-ignore = E203,W503
 max-line-length = 80
 exclude = src/github3/_version.py
+
+[isort]
+profile = black


### PR DESCRIPTION
So many files changes.  "Gotta rip the bandaid off" 😄 

- [x] keep it simple with just `--profile black` argument
- [x] update pull_request_template when asking for python-dateutil version
  - some engineers don't know to prefix `dateutil` with `python-`

This is a premptive strike on #1172 fix

Before opening a new issue, please [search][] for a previously filed
issue to ensure you're not creating a duplicate.

**Note** Bug reports without the following will receive requests for these
details to be provided.

## Version Information

Please provide:

- The version of Python you're using (3.12.2)

- The version of pip you used to install github3.py (24.0)

- The version of github3.py (4.0.1), requests (2.31.0), uritemplate (4.1.1), and python-dateutil (2.9.0-post0) installed

## Minimum Reproducible Example

Please provide an example of the code that generates the error you're seeing.

## Exception information

What is exceptional about what you're seeing versus what you expected to see.

<!-- links -->
[search]: https://github.com/sigmavirus24/github3.py/issues?utf8=%E2%9C%93&q=is%3Aissue
