### PR TITLE
Add support for head_repo param for PR creation

### DIFF
--- a/src/github3/repos/repo.py
+++ b/src/github3/repos/repo.py
@@ -1162,7 +1162,7 @@ class _Repository(models.GitHubCore):
 
     @decorators.requires_auth
     def create_pull(
-        self, title, base, head, body=None, maintainer_can_modify=None
+        self, title, base, head, head_repo=None, body=None, maintainer_can_modify=None
     ):
         """Create a pull request of ``head`` onto ``base`` branch in this repo.
 
@@ -1171,7 +1171,9 @@ class _Repository(models.GitHubCore):
         :param str base:
             (required), e.g., 'master'
         :param str head:
-            (required), e.g., 'username:branch'
+            (required), e.g., 'username:branch' or 'branch' when using head_repo
+        :param str head_repo:
+            (optional), required for cross-repository pull requests if both repositories are owned by the same organization. e.g., 'organization/repository'
         :param str body:
             (optional), markdown formatted description
         :param bool maintainer_can_modify:
@@ -1185,6 +1187,8 @@ class _Repository(models.GitHubCore):
         data = {"title": title, "body": body, "base": base, "head": head}
         if maintainer_can_modify is not None:
             data["maintainer_can_modify"] = maintainer_can_modify
+        if head_repo is not None:
+            data["head_repo"] = head_repo
         return self._create_pull(data)
 
     @decorators.requires_auth

--- a/tests/integration/test_repos_repo.py
+++ b/tests/integration/test_repos_repo.py
@@ -481,6 +481,28 @@ class TestRepository(helper.IntegrationHelper):
 
         assert isinstance(pull_request, github3.pulls.ShortPullRequest)
 
+    def test_create_pull_head_repo(self):
+        """Test the ability to create a pull request by fully specifying the organization, repository, and branch."""
+        self.token_login()
+        cassette_name = self.cassette_name("create_pull")
+        with self.recorder.use_cassette(cassette_name):
+            original_repository = self.gh.repository(
+                "github3py", "github3.py"
+            )
+            repository = original_repository.create_fork(
+                organization="testgh3py"
+            )
+            pull_request = repository.create_pull(
+                title="Update forked repo",
+                base="master",
+                head="develop",
+                head_repo="testgh3py/github3.py",
+                body="Testing the ability to create a pull request",
+            )
+            repository.delete()
+
+        assert isinstance(pull_request, github3.pulls.ShortPullRequest)
+
     def test_create_pull_from_issue(self):
         """Verify creation of a pull request from an issue."""
         self.token_login()


### PR DESCRIPTION
This parameter allows the repository containing the PR branch to be fully specified in the `head_repo` with value of
`organization/repository` and using head parameter for the branch name.

This parameter is required when the fork does not have the same name as the original repository. e.g. when the fork repository is in the same organization as the main repository.

Fixes #1190 