### PR TITLE
Handle anonymous contributors

### DIFF
--- a/src/github3/users.py
+++ b/src/github3/users.py
@@ -971,7 +971,31 @@ class Contributor(_User):
     _refresh_to = User
 
     def _update_attributes(self, contributor):
-        super()._update_attributes(contributor)
+        if "login" in contributor:
+            super()._update_attributes(contributor)
+            self.name = contributor.get("name")
+            self.email = contributor.get("email")
+        else:
+            self.avatar_url = None
+            self.events_urlt = None
+            self.followers_url = None
+            self.following_urlt = None
+            self.gists_urlt = None
+            self.gravatar_id = None
+            self.html_url = None
+            self.id = None
+            self.login = contributor.get("name") or contributor.get("email")
+            self.name = contributor.get("name")
+            self.email = contributor.get("email")
+            self.organizations_url = None
+            self.received_events_url = None
+            self.repos_url = None
+            self.site_admin = None
+            self.starred_urlt = None
+            self.subscriptions_url = None
+            self.type = None
+            self.url = self._api = None
+            self._uniq = self.login
         self.contributions_count = contributor["contributions"]
 
 

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -82,6 +82,30 @@ class TestGhostUser(helper.UnitHelper):
         assert repr(self.instance) == "<User [ghost:Deleted user]>"
 
 
+class TestContributor(helper.UnitHelper):
+    """Test methods on Contributor class."""
+
+    described_class = github3.users.Contributor
+    example_data = dict(get_users_example_data(), contributions=1)
+
+    def test_anonymous_contributor(self):
+        """Show that anonymous contributors are parsed."""
+        contributor = github3.users.Contributor(
+            {
+                "name": "Anonymous Contributor",
+                "email": "anonymous@example.com",
+                "contributions": 3,
+            },
+            self.session,
+        )
+
+        assert contributor.name == "Anonymous Contributor"
+        assert contributor.email == "anonymous@example.com"
+        assert contributor.login == "Anonymous Contributor"
+        assert contributor.contributions_count == 3
+        assert contributor.url is None
+
+
 class TestUserGPGKeyRequiresAuth(helper.UnitRequiresAuthenticationHelper):
     """Unit tests that demonstrate which GPGKey methods require auth."""
 


### PR DESCRIPTION
## What changed

`Contributor` now handles anonymous contributor records returned by the contributors API when `anon=true`. Anonymous records keep their `name`, `email`, and contribution count without trying to parse missing user URL/avatar fields.

## Why

This addresses #891. GitHub can return anonymous contributor records that do not include the full user payload. The previous parsing path always used `_User._update_attributes()`, so it raised `IncompleteResponse` from a missing field such as `avatar_url` before iteration could continue.

## Validation

- `python -m pytest tests\unit\test_users.py::TestContributor -q`
- `python -m pytest tests\unit\test_repos_repo.py::TestRepositoryIterator::test_contributors tests\unit\test_repos_repo.py::TestRepositoryIterator::test_contributors_with_anon -q`
- `python -m compileall -q src\github3\users.py tests\unit\test_users.py`
- `python -m black --check src\github3\users.py tests\unit\test_users.py`
- `python -m flake8 src\github3\users.py tests\unit\test_users.py`
- `git diff --check`