### PR TITLE
fix tests with requests 2.34

### DIFF
--- a/tests/unit/test_github_session.py
+++ b/tests/unit/test_github_session.py
@@ -40,7 +40,7 @@ class TestGitHubSession:
         r = s.get("http://example.com")
         assert r is response
         request_mock.assert_called_once_with(
-            "GET", "http://example.com", allow_redirects=True, timeout=(4, 10)
+            "GET", "http://example.com", params=None, allow_redirects=True, timeout=(4, 10)
         )
 
     @unittest.mock.patch.object(requests.Session, "request")
@@ -57,6 +57,7 @@ class TestGitHubSession:
         request_mock.assert_called_once_with(
             "GET",
             "http://example.com",
+            params=None,
             allow_redirects=True,
             timeout=(300, 400),
         )
@@ -148,7 +149,7 @@ class TestGitHubSession:
         r = s.get("http://example.com")
         assert r is response
         request_mock.assert_called_once_with(
-            "GET", "http://example.com", allow_redirects=True, timeout=(4, 10)
+            "GET", "http://example.com", params=None, allow_redirects=True, timeout=(4, 10)
         )
 
     @unittest.mock.patch.object(requests.Session, "request")

--- a/tests/unit/test_github_session.py
+++ b/tests/unit/test_github_session.py
@@ -40,7 +40,11 @@ class TestGitHubSession:
         r = s.get("http://example.com")
         assert r is response
         request_mock.assert_called_once_with(
-            "GET", "http://example.com", params=None, allow_redirects=True, timeout=(4, 10)
+            "GET",
+            "http://example.com",
+            params=None,
+            allow_redirects=True,
+            timeout=(4, 10),
         )
 
     @unittest.mock.patch.object(requests.Session, "request")
@@ -149,7 +153,11 @@ class TestGitHubSession:
         r = s.get("http://example.com")
         assert r is response
         request_mock.assert_called_once_with(
-            "GET", "http://example.com", params=None, allow_redirects=True, timeout=(4, 10)
+            "GET",
+            "http://example.com",
+            params=None,
+            allow_redirects=True,
+            timeout=(4, 10),
         )
 
     @unittest.mock.patch.object(requests.Session, "request")


### PR DESCRIPTION
This fixes the tests when used with requests library 2.34.2.

I noticed this when tests failed in nixpkgs (nixos).